### PR TITLE
Remove param Foo.class from registerTypeAdapterFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Simply include AutoGson in your project and add the generated Serializer and Des
 }
 
 final Gson gson = new GsonBuilder()
-  .registerTypeAdapterFactory(Foo.class, Foo.typeAdapterFactory())
+  .registerTypeAdapterFactory(Foo.typeAdapterFactory())
   .create();
 ```
 


### PR DESCRIPTION
`registerTypeAdapterFactory` only takes one param according to [Gson Javadocs](http://google.github.io/gson/apidocs/).