### PR TITLE
Use primitive types

### DIFF
--- a/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -2,9 +2,12 @@ package com.ryanharter.auto.value.gson;
 
 import com.google.auto.service.AutoService;
 import com.google.auto.value.extension.AutoValueExtension;
+import com.google.common.base.Defaults;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import com.google.common.primitives.Primitives;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
@@ -296,8 +299,17 @@ public class AutoValueGsonExtension extends AutoValueExtension {
     for (Property prop : adapters.keySet()) {
       FieldSpec field = FieldSpec.builder(prop.type, prop.name).build();
       fields.put(prop, field);
+      if(field.type.isPrimitive()){
+        String defaultValue = getDefaultPrimitiveValue(field.type);
+        if(defaultValue != null) {
+          readMethod.addStatement("$T $N = $L", field.type, field, defaultValue);
+        }else {
+          readMethod.addStatement("$T $N = $T.valueOf(null)", field.type, field, field.type.box());
+        }
 
-      readMethod.addStatement("$T $N = null", field.type.isPrimitive() ? field.type.box() : field.type, field);
+      }else {
+        readMethod.addStatement("$T $N = null", field.type, field);
+      }
     }
 
     readMethod.beginControlFlow("while ($N.hasNext())", jsonReader);
@@ -345,6 +357,34 @@ public class AutoValueGsonExtension extends AutoValueExtension {
     readMethod.addStatement(format.toString(), fields.values().toArray());
 
     return readMethod.build();
+  }
+
+  private String getDefaultPrimitiveValue(TypeName type) {
+    String valueString = null;
+    try {
+      Class<?> primitiveClass = Primitives.unwrap(Class.forName(type.box().toString()));
+      if(primitiveClass != null) {
+        Object defaultValue = Defaults.defaultValue(primitiveClass);
+        if(defaultValue != null) {
+          valueString = defaultValue.toString();
+          if (!Strings.isNullOrEmpty(valueString)) {
+            switch (type.toString()) {
+              case "double":
+                valueString = valueString + "d";
+                break;
+              case "float":
+                valueString = valueString + "f";
+                break;
+              case "long":
+                valueString = valueString + "L";
+            }
+          }
+        }
+      }
+
+    } catch (Exception e) {
+    }
+    return valueString;
   }
 
   private CodeBlock makeType(ParameterizedTypeName type) {

--- a/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -299,15 +299,14 @@ public class AutoValueGsonExtension extends AutoValueExtension {
     for (Property prop : adapters.keySet()) {
       FieldSpec field = FieldSpec.builder(prop.type, prop.name).build();
       fields.put(prop, field);
-      if(field.type.isPrimitive()){
+      if (field.type.isPrimitive()) {
         String defaultValue = getDefaultPrimitiveValue(field.type);
-        if(defaultValue != null) {
+        if (defaultValue != null) {
           readMethod.addStatement("$T $N = $L", field.type, field, defaultValue);
-        }else {
+        } else {
           readMethod.addStatement("$T $N = $T.valueOf(null)", field.type, field, field.type.box());
         }
-
-      }else {
+      } else {
         readMethod.addStatement("$T $N = null", field.type, field);
       }
     }
@@ -368,9 +367,9 @@ public class AutoValueGsonExtension extends AutoValueExtension {
     String valueString = null;
     try {
       Class<?> primitiveClass = Primitives.unwrap(Class.forName(type.box().toString()));
-      if(primitiveClass != null) {
+      if (primitiveClass != null) {
         Object defaultValue = Defaults.defaultValue(primitiveClass);
-        if(defaultValue != null) {
+        if (defaultValue != null) {
           valueString = defaultValue.toString();
           if (!Strings.isNullOrEmpty(valueString)) {
             switch (type.toString()) {

--- a/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -359,6 +359,11 @@ public class AutoValueGsonExtension extends AutoValueExtension {
     return readMethod.build();
   }
 
+  /**
+   *
+   * @param type
+   * @return the default primitive value as a String.  Returns null if unable to determine default value
+     */
   private String getDefaultPrimitiveValue(TypeName type) {
     String valueString = null;
     try {
@@ -377,13 +382,15 @@ public class AutoValueGsonExtension extends AutoValueExtension {
                 break;
               case "long":
                 valueString = valueString + "L";
+                break;
             }
           }
         }
       }
-
-    } catch (Exception e) {
+    } catch (ClassNotFoundException ignored) {
+      //Swallow and return null
     }
+
     return valueString;
   }
 

--- a/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonExtensionTest.java
+++ b/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonExtensionTest.java
@@ -158,7 +158,7 @@ public class AutoValueGsonExtensionTest {
         + "      jsonReader.beginObject();\n"
         + "      String a = null;\n"
         + "      int[] b = null;\n"
-        + "      Integer c = null;\n"
+        + "      int c = 0;\n"
         + "      String d = null;\n"
         + "      String e = null;\n"
         + "      Map<String, Number> f = null;\n"


### PR DESCRIPTION
Use primitive types when possible.  This fixes NullPointerExceptions when properties that are primitive types are not in the supplied json