### PR TITLE
Replaced equals check with isAssignableFrom in  AutoValueGsonTypeAdapterFactory

### DIFF
--- a/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessor.java
+++ b/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessor.java
@@ -101,9 +101,9 @@ public class AutoValueGsonAdapterFactoryProcessor extends AbstractProcessor {
     for (int i = 0, elementsSize = elements.size(); i < elementsSize; i++) {
       Element element = elements.get(i);
       if (i == 0) {
-        create.beginControlFlow("if (rawType.equals($T.class))", element);
+        create.beginControlFlow("if ($T.class.isAssignableFrom(rawType))", element);
       } else {
-        create.nextControlFlow("else if (rawType.equals($T.class))", element);
+        create.nextControlFlow("else if ($T.class.isAssignableFrom(rawType))", element);
       }
       ExecutableElement typeAdapterMethod = getTypeAdapterMethod(element);
       create.addStatement("return (TypeAdapter<$T>) $T." + typeAdapterMethod.getSimpleName() + "($N)", t, element, gson);

--- a/auto-value-gson/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessorTest.java
+++ b/auto-value-gson/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessorTest.java
@@ -2,8 +2,10 @@ package com.ryanharter.auto.value.gson;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.JavaFileObjects;
-import javax.tools.JavaFileObject;
+
 import org.junit.Test;
+
+import javax.tools.JavaFileObject;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
@@ -46,9 +48,9 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
         + "public final class AutoValueGsonTypeAdapterFactory implements TypeAdapterFactory {\n"
         + "  @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {\n"
         + "    Class<T> rawType = (Class<T>) type.getRawType();\n"
-        + "    if (rawType.equals(Foo.class)) {\n"
+        + "    if (Foo.class.isAssignableFrom(rawType)) {\n"
         + "      return (TypeAdapter<T>) Foo.typeAdapter(gson);\n"
-        + "    } else if (rawType.equals(Bar.class)) {\n"
+        + "    } else if (Bar.class.isAssignableFrom(rawType)) {\n"
         + "      return (TypeAdapter<T>) Bar.jsonAdapter(gson);\n"
         + "    } else {\n"
         + "      return null;\n"

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/Address.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/Address.java
@@ -1,0 +1,23 @@
+package com.ryanharter.auto.value.gson.example;
+
+import com.google.auto.value.AutoValue;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.SerializedName;
+
+@AutoValue
+public abstract class Address {
+
+    public static Address create(String streetName, String city) {
+        return new AutoValue_Address(streetName, city);
+    }
+
+    public static TypeAdapter<Address> typeAdapter(Gson gson) {
+        return new AutoValue_Address.GsonTypeAdapter(gson);
+    }
+
+    @SerializedName("street-name")
+    public abstract String streetName();
+
+    public abstract String city();
+}

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/Person.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/Person.java
@@ -12,6 +12,8 @@ public abstract class Person {
 
     public abstract int age();
 
+    public abstract Address address();
+
     public static Builder builder() {
         return new AutoValue_Person.Builder();
     }
@@ -27,6 +29,8 @@ public abstract class Person {
         public abstract Builder gender(int gender);
 
         public abstract Builder age(int age);
+
+        public abstract Builder address(Address address);
 
         public abstract Person build();
     }

--- a/example/src/test/java/com/ryanharter/auto/value/gson/example/PersonTest.java
+++ b/example/src/test/java/com/ryanharter/auto/value/gson/example/PersonTest.java
@@ -16,8 +16,9 @@ public class PersonTest {
                 .name("Piasy")
                 .gender(1)
                 .age(23)
+                .address(Address.create("street", "city"))
                 .build();
-        String json = "{\"name\":\"Piasy\",\"gender\":1,\"age\":23}";
+        String json = "{\"name\":\"Piasy\",\"gender\":1,\"age\":23,\"address\":{\"street-name\":\"street\",\"city\":\"city\"}}";
 
         String toJson = gson.toJson(person, Person.class);
         Assert.assertEquals(json, toJson);


### PR DESCRIPTION
Hi, I am using this framework and it's great!
I have found a small problem in AutoValueGsonTypeAdapterFactory. Sometimes, for example in nested objects, the second parameter of `AutoValueGsonTypeAdapterFactory.create` contains the generated class and not the original one. I have changed the check from `rawType.equals(Person.class)` to `Person.class.isAssignableFrom(rawType)` to fix it.
I updated the example to add a nested object `Address` with a `SerializedName` annotated field, with the equals check it doesn't work (the autogenerated `TypeAdapter<Address>` is not used).