### PR TITLE
Ability to Use Generics on Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ final Gson gson = new GsonBuilder()
   .create();
 ```
 
+If `Foo` used a generic type the static typeAdapter method would require a second parameter, `TypeToken<? extends Foo>`.
+
+```java
+public static TypeAdapter<Foo> typeAdapter(Gson gson, TypeToken<? extends Foo> typeToken) {
+  return new AutoValue_Foo.GsonTypeAdapter(gson, typeToken);
+}
+```
+
 Now build your project and de/serialize your Foo.
 
 In addition to generating implementations of your `@AutoValue` annotated classes, auto-value-gson

--- a/auto-value-gson/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessorTest.java
+++ b/auto-value-gson/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessorTest.java
@@ -36,6 +36,18 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
         + "  }\n"
         + "  public abstract String getName();\n"
         + "}");
+    JavaFileObject source3 = JavaFileObjects.forSourceString("test.Baz", ""
+            + "package test;\n"
+            + "import com.google.auto.value.AutoValue;\n"
+            + "import com.google.gson.TypeAdapter;\n"
+            + "import com.google.gson.reflect.TypeToken;\n"
+            + "import com.google.gson.Gson;\n"
+            + "@AutoValue public abstract class Baz<T> {\n"
+            + "  public static TypeAdapter<Baz> typeAdapter(Gson gson, TypeToken<? extends Baz> typeToken) {\n"
+            + "    return null;\n"
+            + "  }\n"
+            + "  public abstract T getData();\n"
+            + "}");
     JavaFileObject expected = JavaFileObjects.forSourceString("com.ryanharter.auto.value.gson.AutoValueGsonTypeAdapterFactory", ""
         + "package com.ryanharter.auto.value.gson;\n"
         + "import com.google.gson.Gson;\n"
@@ -44,6 +56,7 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
         + "import com.google.gson.reflect.TypeToken;\n"
         + "import java.lang.Override;\n"
         + "import test.Bar;\n"
+        + "import test.Baz;\n"
         + "import test.Foo;\n"
         + "public class AutoValueGsonTypeAdapterFactory implements TypeAdapterFactory {\n"
         + "  @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {\n"
@@ -52,6 +65,8 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
         + "      return (TypeAdapter<T>) Foo.typeAdapter(gson);\n"
         + "    } else if (Bar.class.isAssignableFrom(rawType)) {\n"
         + "      return (TypeAdapter<T>) Bar.jsonAdapter(gson);\n"
+        + "    } else if (Baz.class.isAssignableFrom(rawType)) {\n"
+        + "      return (TypeAdapter<T>) Baz.typeAdapter(gson, (TypeToken<? extends Baz>)type);\n"
         + "    } else {\n"
         + "      return null;\n"
         + "    }\n"
@@ -59,7 +74,7 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
         + "}");
 
     assertAbout(javaSources())
-        .that(ImmutableSet.of(source1, source2))
+        .that(ImmutableSet.of(source1, source2, source3))
         .processedWith(new AutoValueGsonAdapterFactoryProcessor())
         .compilesWithoutError()
         .and()

--- a/auto-value-gson/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonExtensionTest.java
+++ b/auto-value-gson/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonExtensionTest.java
@@ -534,4 +534,324 @@ public class AutoValueGsonExtensionTest {
       .and()
       .generatesSources(expected);
   }
+
+  @Test public void generatesGenericTypeTypeAdapter() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", "" +
+            "package test;\n" +
+            "\n" +
+            "import com.google.auto.value.AutoValue;\n" +
+            "import com.google.gson.Gson;\n" +
+            "import com.google.gson.reflect.TypeToken;\n" +
+            "import com.google.gson.TypeAdapter;\n" +
+            "\n" +
+            "@AutoValue public abstract class Test<T> {\n" +
+            "    public static TypeAdapter<Test> typeAdapter(Gson gson, TypeToken typeToken) {\n" +
+            "        return new AutoValue_Test.GsonTypeAdapter(gson, typeToken);\n" +
+            "    }\n" +
+            "    \n" +
+            "    public abstract T data();\n" +
+            "}\n"
+    );
+
+    JavaFileObject expected = JavaFileObjects.forSourceString("test/AutoValue_Test", "" +
+            "package test;\n" +
+            "\n" +
+            "import com.google.gson.Gson;\n" +
+            "import com.google.gson.TypeAdapter;\n" +
+            "import com.google.gson.reflect.TypeToken;\n" +
+            "import com.google.gson.stream.JsonReader;\n" +
+            "import com.google.gson.stream.JsonToken;\n" +
+            "import com.google.gson.stream.JsonWriter;\n" +
+            "import java.io.IOException;\n" +
+            "import java.lang.Object;\n" +
+            "import java.lang.Override;\n" +
+            "import java.lang.String;\n" +
+            "import java.lang.reflect.ParameterizedType;\n" +
+            "import java.lang.reflect.Type;\n" +
+            "\n" +
+            "final class AutoValue_Test<T> extends $AutoValue_Test<T> {\n" +
+            "  AutoValue_Test(T data) {\n" +
+            "    super(data);\n" +
+            "  }\n" +
+            "\n" +
+            "  public static final class GsonTypeAdapter extends TypeAdapter<Test> {\n" +
+            "    private final TypeAdapter<? super Object> dataAdapter;\n" +
+            "    public GsonTypeAdapter(Gson gson, TypeToken<? extends Test> typeToken) {\n" +
+            "      Type type = typeToken.getType();\n" +
+            "      if (type instanceof ParameterizedType) {\n" +
+            "        ParameterizedType parameterizedType = (ParameterizedType) type;\n" +
+            "        Type[] typeArgs = parameterizedType.getActualTypeArguments();\n" +
+            "        TypeToken token0 = TypeToken.get(typeArgs[0]);\n" +
+            "        this.dataAdapter = gson.getAdapter(token0);\n" +
+            "      } else {\n" +
+            "        this.dataAdapter = gson.getAdapter(Object.class);\n" +
+            "      }\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    public void write(JsonWriter jsonWriter, Test object) throws IOException {\n" +
+            "      jsonWriter.beginObject();\n" +
+            "      jsonWriter.name(\"data\");\n" +
+            "      dataAdapter.write(jsonWriter, object.data());\n" +
+            "      jsonWriter.endObject();\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    public Test read(JsonReader jsonReader) throws IOException {\n" +
+            "      jsonReader.beginObject();\n" +
+            "      Object data = null;\n" +
+            "      while (jsonReader.hasNext()) {\n" +
+            "        String _name = jsonReader.nextName();\n" +
+            "        if (jsonReader.peek() == JsonToken.NULL) {\n" +
+            "          jsonReader.skipValue();\n" +
+            "          continue;\n" +
+            "        }\n" +
+            "        switch (_name) {\n" +
+            "          case \"data\": {\n" +
+            "            data = dataAdapter.read(jsonReader);\n" +
+            "            break;\n" +
+            "          }\n" +
+            "          default: {\n" +
+            "            jsonReader.skipValue();\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "      jsonReader.endObject();\n" +
+            "      return new AutoValue_Test(data);\n" +
+            "    }\n" +
+            "  }\n" +
+            "}"
+    );
+
+    assertAbout(javaSource())
+            .that(source)
+            .processedWith(new AutoValueProcessor())
+            .compilesWithoutError()
+            .withWarningCount(10)
+            .and()
+            .generatesSources(expected);
+  }
+
+  @Test public void generatesGenericTypeTypeAdapterForMultipleGenerics() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", "" +
+            "package test;\n" +
+            "\n" +
+            "import com.google.auto.value.AutoValue;\n" +
+            "import com.google.gson.Gson;\n" +
+            "import com.google.gson.reflect.TypeToken;\n" +
+            "import com.google.gson.TypeAdapter;\n" +
+            "\n" +
+            "@AutoValue public abstract class Test<A, B, C> {\n" +
+            "    public static TypeAdapter<Test> typeAdapter(Gson gson, TypeToken<? extends Test> typeToken) {\n" +
+            "        return new AutoValue_Test.GsonTypeAdapter(gson, typeToken);\n" +
+            "    }\n" +
+            "    \n" +
+            "    public abstract A a();\n" +
+            "    public abstract B b();\n" +
+            "    public abstract C c();\n" +
+            "}\n"
+    );
+
+    JavaFileObject expected = JavaFileObjects.forSourceString("test/AutoValue_Test", "" +
+            "package test;\n" +
+            "\n" +
+            "import com.google.gson.Gson;\n" +
+            "import com.google.gson.TypeAdapter;\n" +
+            "import com.google.gson.reflect.TypeToken;\n" +
+            "import com.google.gson.stream.JsonReader;\n" +
+            "import com.google.gson.stream.JsonToken;\n" +
+            "import com.google.gson.stream.JsonWriter;\n" +
+            "import java.io.IOException;\n" +
+            "import java.lang.Object;\n" +
+            "import java.lang.Override;\n" +
+            "import java.lang.String;\n" +
+            "import java.lang.reflect.ParameterizedType;\n" +
+            "import java.lang.reflect.Type;\n" +
+            "\n" +
+            "final class AutoValue_Test<A, B, C> extends $AutoValue_Test<A, B, C> {\n" +
+            "  AutoValue_Test(A a, B b, C c) {\n" +
+            "    super(a, b, c);\n" +
+            "  }\n" +
+            "\n" +
+            "  public static final class GsonTypeAdapter extends TypeAdapter<Test> {\n" +
+            "    private final TypeAdapter<? super Object> aAdapter;\n" +
+            "    private final TypeAdapter<? super Object> bAdapter;\n" +
+            "    private final TypeAdapter<? super Object> cAdapter;\n" +
+            "    public GsonTypeAdapter(Gson gson, TypeToken<? extends Test> typeToken) {\n" +
+            "      Type type = typeToken.getType();\n" +
+            "      if (type instanceof ParameterizedType) {\n" +
+            "        ParameterizedType parameterizedType = (ParameterizedType) type;\n" +
+            "        Type[] typeArgs = parameterizedType.getActualTypeArguments();\n" +
+            "        TypeToken token0 = TypeToken.get(typeArgs[0]);\n" +
+            "        this.aAdapter = gson.getAdapter(token0);\n" +
+            "        TypeToken token1 = TypeToken.get(typeArgs[1]);\n" +
+            "        this.bAdapter = gson.getAdapter(token1);\n" +
+            "        TypeToken token2 = TypeToken.get(typeArgs[2]);\n" +
+            "        this.cAdapter = gson.getAdapter(token2);\n" +
+            "      } else {\n" +
+            "        this.aAdapter = gson.getAdapter(Object.class);\n" +
+            "        this.bAdapter = gson.getAdapter(Object.class);\n" +
+            "        this.cAdapter = gson.getAdapter(Object.class);\n" +
+            "      }\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    public void write(JsonWriter jsonWriter, Test object) throws IOException {\n" +
+            "      jsonWriter.beginObject();\n" +
+            "      jsonWriter.name(\"a\");\n" +
+            "      aAdapter.write(jsonWriter, object.a());\n" +
+            "      jsonWriter.name(\"b\");\n" +
+            "      bAdapter.write(jsonWriter, object.b());\n" +
+            "      jsonWriter.name(\"c\");\n" +
+            "      cAdapter.write(jsonWriter, object.c());\n" +
+            "      jsonWriter.endObject();\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    public Test read(JsonReader jsonReader) throws IOException {\n" +
+            "      jsonReader.beginObject();\n" +
+            "      Object a = null;\n" +
+            "      Object b = null;\n" +
+            "      Object c = null;\n" +
+            "      while (jsonReader.hasNext()) {\n" +
+            "        String _name = jsonReader.nextName();\n" +
+            "        if (jsonReader.peek() == JsonToken.NULL) {\n" +
+            "          jsonReader.skipValue();\n" +
+            "          continue;\n" +
+            "        }\n" +
+            "        switch (_name) {\n" +
+            "          case \"a\": {\n" +
+            "            a = aAdapter.read(jsonReader);\n" +
+            "            break;\n" +
+            "          }\n" +
+            "          case \"b\": {\n" +
+            "            b = bAdapter.read(jsonReader);\n" +
+            "            break;\n" +
+            "          }\n" +
+            "          case \"c\": {\n" +
+            "            c = cAdapter.read(jsonReader);\n" +
+            "            break;\n" +
+            "          }\n" +
+            "          default: {\n" +
+            "            jsonReader.skipValue();\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "      jsonReader.endObject();\n" +
+            "      return new AutoValue_Test(a, b, c);\n" +
+            "    }\n" +
+            "  }\n" +
+            "}\n"
+    );
+
+    assertAbout(javaSource())
+            .that(source)
+            .processedWith(new AutoValueProcessor())
+            .compilesWithoutError()
+            .withWarningCount(12)
+            .and()
+            .generatesSources(expected);
+  }
+
+  @Test public void generatesGenericTypeTypeAdapterWithNoGenericTypes() {
+    JavaFileObject source = JavaFileObjects.forSourceString("test.Test", "" +
+            "package test;\n" +
+            "\n" +
+            "import com.google.auto.value.AutoValue;\n" +
+            "import com.google.gson.Gson;\n" +
+            "import com.google.gson.reflect.TypeToken;\n" +
+            "import com.google.gson.TypeAdapter;\n" +
+            "\n" +
+            "@AutoValue public abstract class Test<T> {\n" +
+            "    public static TypeAdapter<Test> typeAdapter(Gson gson, TypeToken<? extends Test> typeToken) {\n" +
+            "        return new AutoValue_Test.GsonTypeAdapter(gson, typeToken);\n" +
+            "    }\n" +
+            "    \n" +
+            "    public abstract T data();\n" +
+            "    public abstract int id();\n" +
+            "}\n"
+    );
+
+    JavaFileObject expected = JavaFileObjects.forSourceString("test/AutoValue_Test", "" +
+            "package test;\n" +
+            "\n" +
+            "import com.google.gson.Gson;\n" +
+            "import com.google.gson.TypeAdapter;\n" +
+            "import com.google.gson.reflect.TypeToken;\n" +
+            "import com.google.gson.stream.JsonReader;\n" +
+            "import com.google.gson.stream.JsonToken;\n" +
+            "import com.google.gson.stream.JsonWriter;\n" +
+            "import java.io.IOException;\n" +
+            "import java.lang.Integer;\n" +
+            "import java.lang.Object;\n" +
+            "import java.lang.Override;\n" +
+            "import java.lang.String;\n" +
+            "import java.lang.reflect.ParameterizedType;\n" +
+            "import java.lang.reflect.Type;\n" +
+            "\n" +
+            "final class AutoValue_Test<T> extends $AutoValue_Test<T> {\n" +
+            "  AutoValue_Test(T data, int id) {\n" +
+            "    super(data, id);\n" +
+            "  }\n" +
+            "\n" +
+            "  public static final class GsonTypeAdapter extends TypeAdapter<Test> {\n" +
+            "    private final TypeAdapter<? super Object> dataAdapter;\n" +
+            "    private final TypeAdapter<Integer> idAdapter;\n" +
+            "    public GsonTypeAdapter(Gson gson, TypeToken<? extends Test> typeToken) {\n" +
+            "      this.idAdapter = gson.getAdapter(Integer.class);\n" +
+            "      Type type = typeToken.getType();\n" +
+            "      if (type instanceof ParameterizedType) {\n" +
+            "        ParameterizedType parameterizedType = (ParameterizedType) type;\n" +
+            "        Type[] typeArgs = parameterizedType.getActualTypeArguments();\n" +
+            "        TypeToken token0 = TypeToken.get(typeArgs[0]);\n" +
+            "        this.dataAdapter = gson.getAdapter(token0);\n" +
+            "      } else {\n" +
+            "        this.dataAdapter = gson.getAdapter(Object.class);\n" +
+            "      }\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    public void write(JsonWriter jsonWriter, Test object) throws IOException {\n" +
+            "      jsonWriter.beginObject();\n" +
+            "      jsonWriter.name(\"data\");\n" +
+            "      dataAdapter.write(jsonWriter, object.data());\n" +
+            "      jsonWriter.name(\"id\");\n" +
+            "      idAdapter.write(jsonWriter, object.id());\n" +
+            "      jsonWriter.endObject();\n" +
+            "    }\n" +
+            "    @Override\n" +
+            "    public Test read(JsonReader jsonReader) throws IOException {\n" +
+            "      jsonReader.beginObject();\n" +
+            "      Object data = null;\n" +
+            "      int id = 0;\n" +
+            "      while (jsonReader.hasNext()) {\n" +
+            "        String _name = jsonReader.nextName();\n" +
+            "        if (jsonReader.peek() == JsonToken.NULL) {\n" +
+            "          jsonReader.skipValue();\n" +
+            "          continue;\n" +
+            "        }\n" +
+            "        switch (_name) {\n" +
+            "          case \"data\": {\n" +
+            "            data = dataAdapter.read(jsonReader);\n" +
+            "            break;\n" +
+            "          }\n" +
+            "          case \"id\": {\n" +
+            "            id = idAdapter.read(jsonReader);\n" +
+            "            break;\n" +
+            "          }\n" +
+            "          default: {\n" +
+            "            jsonReader.skipValue();\n" +
+            "          }\n" +
+            "        }\n" +
+            "      }\n" +
+            "      jsonReader.endObject();\n" +
+            "      return new AutoValue_Test(data, id);\n" +
+            "    }\n" +
+            "  }\n" +
+            "}"
+    );
+
+    assertAbout(javaSource())
+            .that(source)
+            .processedWith(new AutoValueProcessor())
+            .compilesWithoutError()
+            .withWarningCount(10)
+            .and()
+            .generatesSources(expected);
+  }
 }

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/Response.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/Response.java
@@ -1,0 +1,25 @@
+package com.ryanharter.auto.value.gson.example;
+
+import com.google.auto.value.AutoValue;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+
+@AutoValue
+public abstract class Response<T> {
+    public abstract T data();
+
+    public static TypeAdapter<Response> typeAdapter(Gson gson, TypeToken<? extends Response> typeToken) {
+        return new AutoValue_Response.GsonTypeAdapter(gson, typeToken);
+    }
+
+    public static <T> Builder<T> builder() {
+        return new AutoValue_Response.Builder<>();
+    }
+
+    @AutoValue.Builder
+    public static abstract class Builder<T> {
+        public abstract Builder<T> data(T data);
+        public abstract Response<T> build();
+    }
+}

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/Tuple3.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/Tuple3.java
@@ -1,0 +1,30 @@
+package com.ryanharter.auto.value.gson.example;
+
+import com.google.auto.value.AutoValue;
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+
+@AutoValue
+public abstract class Tuple3<A, B, C> {
+
+    public static TypeAdapter<Tuple3> typeAdapter(Gson gson, TypeToken<? extends Tuple3> typeToken) {
+        return new AutoValue_Tuple3.GsonTypeAdapter(gson, typeToken);
+    }
+
+    public static <A, B, C> Builder<A, B, C> builder() {
+        return new AutoValue_Tuple3.Builder<>();
+    }
+
+    public abstract A a();
+    public abstract B b();
+    public abstract C c();
+
+    @AutoValue.Builder
+    public static abstract class Builder<A, B, C> {
+        public abstract Builder<A, B, C> a(A a);
+        public abstract Builder<A, B, C> b(B b);
+        public abstract Builder<A, B, C> c(C c);
+        public abstract Tuple3<A, B, C> build();
+    }
+}

--- a/example/src/test/java/com/ryanharter/auto/value/gson/example/ResponseTest.java
+++ b/example/src/test/java/com/ryanharter/auto/value/gson/example/ResponseTest.java
@@ -1,0 +1,37 @@
+package com.ryanharter.auto.value.gson.example;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+import com.ryanharter.auto.value.gson.AutoValueGsonTypeAdapterFactory;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+
+public class ResponseTest {
+    @Test
+    public void testGson() throws Exception {
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapterFactory(new AutoValueGsonTypeAdapterFactory())
+                .create();
+
+
+        List<String> expected = Arrays.asList("Hello", "World");
+        Type responseType = new TypeToken<Response<List<String>>>(){}.getType();
+
+
+        Response<List<String>> response = Response.<List<String>>builder()
+                .data(expected)
+                .build();
+        String json = "{\"data\":[\"Hello\",\"World\"]}";
+
+        String toJson = gson.toJson(response, responseType);
+        Assert.assertEquals(json, toJson);
+
+        Response<List<String>> fromJson = gson.fromJson(json, responseType);
+        Assert.assertEquals(expected, fromJson.data());
+    }
+}

--- a/example/src/test/java/com/ryanharter/auto/value/gson/example/Tupe3Test.java
+++ b/example/src/test/java/com/ryanharter/auto/value/gson/example/Tupe3Test.java
@@ -1,0 +1,43 @@
+package com.ryanharter.auto.value.gson.example;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.ryanharter.auto.value.gson.AutoValueGsonTypeAdapterFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class Tupe3Test {
+    @Test public void testGson() throws Exception {
+        Gson gson = new GsonBuilder()
+                .registerTypeAdapterFactory(new AutoValueGsonTypeAdapterFactory())
+                .create();
+
+        TypeToken<Tuple3<Integer, String, List<String>>> tuple3TypeToken
+                = new TypeToken<Tuple3<Integer, String, List<String>>>() {};
+
+        int expectedA = 1;
+        String expectedB = "Testing";
+        List<String> expectedC = Arrays.asList("Hello", "World");
+
+        Tuple3<Integer, String, List<String>> tuple3 = Tuple3.<Integer, String, List<String>>builder()
+                .a(expectedA)
+                .b(expectedB)
+                .c(expectedC)
+                .build();
+
+        String json = "{\"a\":1,\"b\":\"Testing\",\"c\":[\"Hello\",\"World\"]}";
+
+        String toJson = gson.toJson(tuple3, tuple3TypeToken.getType());
+        Assert.assertEquals(json, toJson);
+
+        Tuple3<Integer, String, List<String>> fromJson = gson.fromJson(json, tuple3TypeToken.getType());
+        Assert.assertEquals((long) expectedA, (long) fromJson.a());
+        Assert.assertEquals(expectedB, fromJson.b());
+        Assert.assertEquals(expectedC, fromJson.c());
+    }
+}


### PR DESCRIPTION
Models that are annotated with `@AutoValue` are now able to use generic types
with gson.

The static method to create the type adapter now requires a typetoken in order
for generic to work.

For example:

```
@AutoValue public abstract class Test<T> {
  public static TypeAdapter<Test> typeAdapter(Gson gson, TypeToken typeToken) {
    return new AutoValue_Test.GsonTypeAdapter(gson, typeToken);
  }

  public abstract T data();
}
```