### PR TITLE
Switch to autovalue-esque style of generating Factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,37 @@ final Gson gson = new GsonBuilder()
 
 Now build your project and de/serialize your Foo.
 
-In addition to generating implementations of your `@AutoValue` annotated classes, auto-value-gson
-also generates an `AutoValueGsonTypeAdapterFactory` class which you can register with your 
-`GsonBuilder` to automatically add all of your generated TypeAdapters.
+## Factory
+
+Optionally, auto-value-gson can create a single [TypeAdapterFactory](https://google.github.io/gson/apidocs/com/google/gson/TypeAdapterFactory.html) so
+that you don't have to add each generated TypeAdapter to your Gson instance manually.
+
+To generate a `TypeAdapterFactory` for all of your auto-value-gson classes, simply create
+an abstract class that implements `TypeAdapterFactory` and annotate it with `@GsonTypeAdapterFactory`,
+and auto-value-gson will create an implementation for you.  You simply need to provide a static
+factory method, just like your AutoValue classes, and you can use the generated `TypeAdapterFactory`
+to help Gson de/serialize your types.
+
+```java
+@GsonTypeAdapterFactory
+public abstract class MyAdapterFactory implements TypeAdapterFactory {
+
+  // Static factory method to access the package
+  // private generated implementation
+  public static TypeAdapterFactory create() {
+    return new AutoValueGson_MyAdapterFactory();
+  }
+  
+}
+```
+
+Then you simply need to register the Factory with Gson.
+
+```java
+Gson gson = new GsonBuilder()
+    .registerTypeAdapterFactory(MyAdapterFactory.create())
+    .build();
+```
 
 ## Download
 

--- a/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessor.java
+++ b/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessor.java
@@ -7,7 +7,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
+import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.reflect.TypeToken;
+import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
@@ -29,12 +31,18 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
-import javax.tools.Diagnostic;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
 
+import static javax.lang.model.element.Modifier.ABSTRACT;
 import static javax.lang.model.element.Modifier.FINAL;
 import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.tools.Diagnostic.Kind.ERROR;
 
 /**
  * Generates a Gson {@link TypeAdapterFactory} that adapts all {@link AutoValue} annotated
@@ -44,13 +52,21 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 public class AutoValueGsonAdapterFactoryProcessor extends AbstractProcessor {
 
   private final AutoValueGsonExtension extension = new AutoValueGsonExtension();
+  private Types typeUtils;
+  private Elements elementUtils;
 
   @Override public Set<String> getSupportedAnnotationTypes() {
-    return ImmutableSet.of(AutoValue.class.getName());
+    return ImmutableSet.of(AutoValue.class.getName(), GsonTypeAdapterFactory.class.getName());
   }
 
   @Override public SourceVersion getSupportedSourceVersion() {
     return SourceVersion.latestSupported();
+  }
+
+  @Override public synchronized void init(ProcessingEnvironment processingEnv) {
+    super.init(processingEnv);
+    typeUtils = processingEnv.getTypeUtils();
+    elementUtils = processingEnv.getElementUtils();
   }
 
   @Override
@@ -64,13 +80,24 @@ public class AutoValueGsonAdapterFactoryProcessor extends AbstractProcessor {
     }
 
     if (!elements.isEmpty()) {
-      TypeSpec typeAdapterFactory = createTypeAdapterFactory(elements);
-      JavaFile file = JavaFile.builder("com.ryanharter.auto.value.gson", typeAdapterFactory).build();
-      try {
-        file.writeTo(processingEnv.getFiler());
-      } catch (IOException e) {
-        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR,
-            "Failed to write TypeAdapterFactory: " + e.getLocalizedMessage());
+      Set<? extends Element> adaptorFactories = roundEnv.getElementsAnnotatedWith(GsonTypeAdapterFactory.class);
+      for (Element element : adaptorFactories) {
+        if (!element.getModifiers().contains(ABSTRACT)) {
+          error(element, "Must be abstract!");
+        }
+        TypeElement type = (TypeElement) element; // Safe to cast because this is only applicable on types anyway
+        if (!implementsTypeAdapterFactory(type)) {
+          error(element, "Must implement TypeAdapterFactory!");
+        }
+        String adapterName = classNameOf(type);
+        String packageName = packageNameOf(type);
+        TypeSpec typeAdapterFactory = createTypeAdapterFactory(elements, packageName, adapterName);
+        JavaFile file = JavaFile.builder(packageName, typeAdapterFactory).build();
+        try {
+          file.writeTo(processingEnv.getFiler());
+        } catch (IOException e) {
+          processingEnv.getMessager().printMessage(ERROR, "Failed to write TypeAdapterFactory: " + e.getLocalizedMessage());
+        }
       }
     }
 
@@ -78,11 +105,14 @@ public class AutoValueGsonAdapterFactoryProcessor extends AbstractProcessor {
     return false;
   }
 
-  private TypeSpec createTypeAdapterFactory(List<Element> elements) {
+  private TypeSpec createTypeAdapterFactory(
+      List<Element> elements,
+      String packageName,
+      String adapterName) {
     TypeSpec.Builder factory = TypeSpec.classBuilder(
-        ClassName.get("com.ryanharter.auto.value.gson", "AutoValueGsonTypeAdapterFactory"));
-    factory.addModifiers(PUBLIC);
-    factory.addSuperinterface(TypeName.get(TypeAdapterFactory.class));
+        ClassName.get(packageName, "AutoValueGson_" + adapterName));
+    factory.addModifiers(PUBLIC, FINAL);
+    factory.superclass(ClassName.get(packageName, adapterName));
 
     ParameterSpec gson = ParameterSpec.builder(Gson.class, "gson").build();
     TypeVariableName t = TypeVariableName.get("T");
@@ -94,6 +124,9 @@ public class AutoValueGsonAdapterFactoryProcessor extends AbstractProcessor {
         .addModifiers(PUBLIC)
         .addTypeVariable(t)
         .addAnnotation(Override.class)
+        .addAnnotation(AnnotationSpec.builder(SuppressWarnings.class)
+            .addMember("value", "\"unchecked\"")
+            .build())
         .addParameters(ImmutableSet.of(gson, type))
         .returns(result)
         .addStatement("Class<$T> rawType = (Class<$T>) $N.getRawType()", t, t, type);
@@ -129,6 +162,72 @@ public class AutoValueGsonAdapterFactoryProcessor extends AbstractProcessor {
       }
     }
     return null;
+  }
+
+  private void error(Element element, String message, Object... args) {
+    if (args.length > 0) {
+      message = String.format(message, args);
+    }
+    processingEnv.getMessager().printMessage(ERROR, message, element);
+  }
+
+  private boolean implementsTypeAdapterFactory(TypeElement type) {
+    TypeMirror typeAdapterFactoryType
+        = elementUtils.getTypeElement(TypeAdapterFactory.class.getCanonicalName()).asType();
+    TypeMirror typeMirror = type.asType();
+    if (!type.getInterfaces().isEmpty() || typeMirror.getKind() != TypeKind.NONE) {
+      while (typeMirror.getKind() != TypeKind.NONE) {
+        if (searchInterfacesAncestry(typeMirror, typeAdapterFactoryType)) {
+          return true;
+        }
+        type = (TypeElement) typeUtils.asElement(typeMirror);
+        typeMirror = type.getSuperclass();
+      }
+    }
+    return false;
+  }
+
+  private boolean searchInterfacesAncestry(TypeMirror rootIface, TypeMirror target) {
+    TypeElement rootIfaceElement = (TypeElement) typeUtils.asElement(rootIface);
+    // check if it implements valid interfaces
+    for (TypeMirror iface : rootIfaceElement.getInterfaces()) {
+      TypeElement ifaceElement = (TypeElement) typeUtils.asElement(rootIface);
+      while (iface.getKind() != TypeKind.NONE) {
+        if (typeUtils.isSameType(iface, target)) {
+          return true;
+        }
+        // go up
+        if (searchInterfacesAncestry(iface, target)) {
+          return true;
+        }
+        // then move on
+        iface = ifaceElement.getSuperclass();
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Returns the name of the given type, including any enclosing types but not the package.
+   */
+  private static String classNameOf(TypeElement type) {
+    String name = type.getQualifiedName().toString();
+    String pkgName = packageNameOf(type);
+    return pkgName.isEmpty() ? name : name.substring(pkgName.length() + 1);
+  }
+
+  /**
+   * Returns the name of the package that the given type is in. If the type is in the default
+   * (unnamed) package then the name is the empty string.
+   */
+  private static String packageNameOf(TypeElement type) {
+    while (true) {
+      Element enclosing = type.getEnclosingElement();
+      if (enclosing instanceof PackageElement) {
+        return ((PackageElement) enclosing).getQualifiedName().toString();
+      }
+      type = (TypeElement) enclosing;
+    }
   }
 
   private static class LimitedContext implements AutoValueExtension.Context {

--- a/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/GsonTypeAdapterFactory.java
+++ b/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/GsonTypeAdapterFactory.java
@@ -1,0 +1,28 @@
+package com.ryanharter.auto.value.gson;
+
+import com.google.gson.TypeAdapterFactory;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.SOURCE;
+
+/**
+ * Annotation to indicate that a given class should generate a concrete implementation of a
+ * {@link TypeAdapterFactory} that handles all the publicly denoted adapter implementations of this
+ * project.
+ * <p>
+ * <code><pre>
+ *   &#64;GsonTypeAdapterFactory
+ *   public abstract class Factory implements TypeAdapterFactory {
+ *     public static Factory create() {
+ *       return new AutoValueGson_Factory();
+ *     }
+ *   }
+ * </pre></code>
+ */
+@Retention(SOURCE)
+@Target(TYPE)
+public @interface GsonTypeAdapterFactory {
+}

--- a/auto-value-gson/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessorTest.java
+++ b/auto-value-gson/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessorTest.java
@@ -2,10 +2,8 @@ package com.ryanharter.auto.value.gson;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.testing.compile.JavaFileObjects;
-
-import org.junit.Test;
-
 import javax.tools.JavaFileObject;
+import org.junit.Test;
 
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.testing.compile.JavaSourcesSubjectFactory.javaSources;
@@ -36,17 +34,28 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
         + "  }\n"
         + "  public abstract String getName();\n"
         + "}");
-    JavaFileObject expected = JavaFileObjects.forSourceString("com.ryanharter.auto.value.gson.AutoValueGsonTypeAdapterFactory", ""
-        + "package com.ryanharter.auto.value.gson;\n"
+    JavaFileObject source3 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+        + "package test;\n"
+        + "import com.google.gson.TypeAdapterFactory;\n"
+        + "import com.ryanharter.auto.value.gson.GsonTypeAdapterFactory;\n"
+        + "@GsonTypeAdapterFactory\n"
+        + "public abstract class MyAdapterFactory implements TypeAdapterFactory {\n"
+        + "  public static TypeAdapterFactory create() {\n"
+        + "    return new AutoValueGson_MyAdapterFactory();\n"
+        + "  }\n"
+        + "}");
+    JavaFileObject expected = JavaFileObjects.forSourceString("test.AutoValueGson_MyAdapterFactory", ""
+        + "package test;\n"
         + "import com.google.gson.Gson;\n"
         + "import com.google.gson.TypeAdapter;\n"
-        + "import com.google.gson.TypeAdapterFactory;\n"
         + "import com.google.gson.reflect.TypeToken;\n"
         + "import java.lang.Override;\n"
-        + "import test.Bar;\n"
-        + "import test.Foo;\n"
-        + "public class AutoValueGsonTypeAdapterFactory implements TypeAdapterFactory {\n"
-        + "  @Override public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "\n"
+        + "public final class AutoValueGson_MyAdapterFactory extends MyAdapterFactory {\n"
+        + "  @Override\n"
+        + "  @SuppressWarnings(\"unchecked\")\n"
+        + "  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {\n"
         + "    Class<T> rawType = (Class<T>) type.getRawType();\n"
         + "    if (Foo.class.isAssignableFrom(rawType)) {\n"
         + "      return (TypeAdapter<T>) Foo.typeAdapter(gson);\n"
@@ -59,11 +68,153 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
         + "}");
 
     assertAbout(javaSources())
-        .that(ImmutableSet.of(source1, source2))
+        .that(ImmutableSet.of(source1, source2, source3))
         .processedWith(new AutoValueGsonAdapterFactoryProcessor())
         .compilesWithoutError()
         .and()
         .generatesSources(expected);
   }
 
+  @Test public void generatesTypeAdapterFactory_notAbstract_shouldFail() {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.google.gson.TypeAdapter;\n"
+        + "import com.google.gson.Gson;\n"
+        + "@AutoValue public abstract class Foo {\n"
+        + "  public static TypeAdapter<Foo> typeAdapter(Gson gson) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "  public abstract boolean isAwesome();\n"
+        + "}");
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+        + "package test;\n"
+        + "import com.google.gson.TypeAdapterFactory;\n"
+        + "import com.ryanharter.auto.value.gson.GsonTypeAdapterFactory;\n"
+        + "@GsonTypeAdapterFactory\n"
+        + "public class MyAdapterFactory implements TypeAdapterFactory {\n"
+        + "  public static TypeAdapterFactory create() {\n"
+        + "    return new AutoValueGson_MyAdapterFactory();\n"
+        + "  }\n"
+        + "}");
+
+    assertAbout(javaSources())
+        .that(ImmutableSet.of(source1, source2))
+        .processedWith(new AutoValueGsonAdapterFactoryProcessor())
+        .failsToCompile()
+        .withErrorContaining("Must be abstract!");
+  }
+
+  @Test public void generatesTypeAdapterFactory_doesNotImplementTypeAdapterFactory_shouldFail() {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.google.gson.TypeAdapter;\n"
+        + "import com.google.gson.Gson;\n"
+        + "@AutoValue public abstract class Foo {\n"
+        + "  public static TypeAdapter<Foo> typeAdapter(Gson gson) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "  public abstract boolean isAwesome();\n"
+        + "}");
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.Bar", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.google.gson.TypeAdapter;\n"
+        + "import com.google.gson.Gson;\n"
+        + "@AutoValue public abstract class Bar {\n"
+        + "  public static TypeAdapter<Bar> jsonAdapter(Gson gson) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "}");
+    JavaFileObject source3 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+        + "package test;\n"
+        + "import com.google.gson.TypeAdapterFactory;\n"
+        + "import com.ryanharter.auto.value.gson.GsonTypeAdapterFactory;\n"
+        + "@GsonTypeAdapterFactory\n"
+        + "public abstract class MyAdapterFactory {\n"
+        + "  public static TypeAdapterFactory create() {\n"
+        + "    return new AutoValueGson_MyAdapterFactory();\n"
+        + "  }\n"
+        + "}");
+
+    assertAbout(javaSources())
+        .that(ImmutableSet.of(source1, source2, source3))
+        .processedWith(new AutoValueGsonAdapterFactoryProcessor())
+        .failsToCompile()
+        .withErrorContaining("Must implement TypeAdapterFactory!");
+  }
+
+  @Test public void generatesTypeAdapterFactory_shouldSearchUpComplexAncestry() {
+    JavaFileObject source1 = JavaFileObjects.forSourceString("test.Foo", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.google.gson.TypeAdapter;\n"
+        + "import com.google.gson.Gson;\n"
+        + "@AutoValue public abstract class Foo {\n"
+        + "  public static TypeAdapter<Foo> typeAdapter(Gson gson) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "  public abstract boolean isAwesome();\n"
+        + "}");
+    JavaFileObject source2 = JavaFileObjects.forSourceString("test.Bar", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.google.gson.TypeAdapter;\n"
+        + "import com.google.gson.Gson;\n"
+        + "@AutoValue public abstract class Bar {\n"
+        + "  public static TypeAdapter<Bar> jsonAdapter(Gson gson) {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "}");
+    JavaFileObject source3 = JavaFileObjects.forSourceString("test.IMyAdapterFactoryBase", ""
+        + "package test;\n"
+        + "import com.google.gson.TypeAdapterFactory;\n"
+        + "public interface IMyAdapterFactoryBase extends TypeAdapterFactory {\n"
+        + "}");
+    JavaFileObject source4 = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
+        + "package test;\n"
+        + "import com.google.gson.TypeAdapterFactory;\n"
+        + "import com.ryanharter.auto.value.gson.GsonTypeAdapterFactory;\n"
+        + "@GsonTypeAdapterFactory\n"
+        + "public abstract class MyAdapterFactory implements IMyAdapterFactoryBase {\n"
+        + "  public static TypeAdapterFactory create() {\n"
+        + "    return new AutoValueGson_MyAdapterFactory();\n"
+        + "  }\n"
+        + "}");
+    JavaFileObject expected = JavaFileObjects.forSourceString("test.AutoValueGson_MyAdapterFactory", ""
+        + "package test;\n"
+        + "import com.google.gson.Gson;\n"
+        + "import com.google.gson.TypeAdapter;\n"
+        + "import com.google.gson.reflect.TypeToken;\n"
+        + "import java.lang.Override;\n"
+        + "import java.lang.SuppressWarnings;\n"
+        + "\n"
+        + "public final class AutoValueGson_MyAdapterFactory extends MyAdapterFactory {\n"
+        + "  @Override\n"
+        + "  @SuppressWarnings(\"unchecked\")\n"
+        + "  public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {\n"
+        + "    Class<T> rawType = (Class<T>) type.getRawType();\n"
+        + "    if (Foo.class.isAssignableFrom(rawType)) {\n"
+        + "      return (TypeAdapter<T>) Foo.typeAdapter(gson);\n"
+        + "    } else if (Bar.class.isAssignableFrom(rawType)) {\n"
+        + "      return (TypeAdapter<T>) Bar.jsonAdapter(gson);\n"
+        + "    } else {\n"
+        + "      return null;\n"
+        + "    }\n"
+        + "  }\n"
+        + "}");
+
+    assertAbout(javaSources())
+        .that(ImmutableSet.of(source1, source2, source3, source4))
+        .processedWith(new AutoValueGsonAdapterFactoryProcessor())
+        .compilesWithoutError()
+        .and()
+        .generatesSources(expected);
+  }
 }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     compileOnly 'com.google.auto.value:auto-value:1.2'
     apt 'com.google.auto.value:auto-value:1.2'
     apt project(':auto-value-gson')
+    compileOnly project(':auto-value-gson')
 
     testCompile 'junit:junit:4.12'
 }

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/SampleAdapterFactory.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/SampleAdapterFactory.java
@@ -1,0 +1,11 @@
+package com.ryanharter.auto.value.gson.example;
+
+import com.google.gson.TypeAdapterFactory;
+
+@com.ryanharter.auto.value.gson.GsonTypeAdapterFactory
+public abstract class SampleAdapterFactory implements TypeAdapterFactory {
+
+    public static SampleAdapterFactory create() {
+        return new AutoValueGson_SampleAdapterFactory();
+    }
+}

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/SampleAdapterFactory.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/SampleAdapterFactory.java
@@ -1,8 +1,9 @@
 package com.ryanharter.auto.value.gson.example;
 
 import com.google.gson.TypeAdapterFactory;
+import com.ryanharter.auto.value.gson.GsonTypeAdapterFactory;
 
-@com.ryanharter.auto.value.gson.GsonTypeAdapterFactory
+@GsonTypeAdapterFactory
 public abstract class SampleAdapterFactory implements TypeAdapterFactory {
 
     public static SampleAdapterFactory create() {

--- a/example/src/test/java/com/ryanharter/auto/value/gson/example/PersonTest.java
+++ b/example/src/test/java/com/ryanharter/auto/value/gson/example/PersonTest.java
@@ -4,13 +4,12 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.junit.Assert;
 import org.junit.Test;
-import com.ryanharter.auto.value.gson.AutoValueGsonTypeAdapterFactory;
 
 public class PersonTest {
     @Test
     public void testGson() throws Exception {
         Gson gson = new GsonBuilder()
-                .registerTypeAdapterFactory(new AutoValueGsonTypeAdapterFactory())
+                .registerTypeAdapterFactory(SampleAdapterFactory.create())
                 .create();
         Person person = Person.builder()
                 .name("Piasy")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.ryanharter.auto.value
-VERSION_NAME=0.3.2-SNAPSHOT
+VERSION_NAME=0.4.0-SNAPSHOT
 
 POM_DESCRIPTION=AutoValue extension that creates a Gson TypeAdapterFactory
 


### PR DESCRIPTION
Followup from https://github.com/rharter/auto-value-moshi/pull/47 and resolves #52 and resolves #58. 

(copying over from https://github.com/rharter/auto-value-moshi/pull/47)

This would be a breaking change, but for the better I think as it'd be a bit muddled to try to maintain the old behavior and this one's as well.

Now, people would have to declare their own @GsonTypeAdapterFactory class(es) to specify where they want it generated.

```java
@GsonTypeAdapterFactory
public abstract class MyAdapterFactory implements TypeAdapterFactory {
  // Static factory method to access the package
  // private generated implementation
  public static TypeAdapterFactory create() {
    return new AutoValueGson_MyAdapterFactory();
  }
}
```