### PR TITLE
Use getDeclaredClass() instead of getClass() on enums

### DIFF
--- a/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -362,7 +362,7 @@ public class AutoValueGsonExtension extends AutoValueExtension {
         .addParameter(jsonReader)
         .addException(IOException.class);
 
-    ClassName token = ClassName.get(JsonToken.NULL.getClass());
+    ClassName token = ClassName.get(JsonToken.NULL.getDeclaringClass());
 
     readMethod.addStatement("$N.beginObject()", jsonReader);
 


### PR DESCRIPTION
If `JsonToken.NULL` declared any instance members, `getClass()` would return
a synthetic subclass of `JsonToken.class`.

This fixes an Error Prone warning: http://errorprone.info/bugpattern/GetClassOnEnum