### PR TITLE
set auto-service dependency to compileOnly

### DIFF
--- a/auto-value-gson/build.gradle
+++ b/auto-value-gson/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.8.0'
     compile 'com.squareup:javapoet:1.8.0'
     compile 'com.google.auto.value:auto-value:1.3'
-    compile 'com.google.auto.service:auto-service:1.0-rc2'
+    compileOnly 'com.google.auto.service:auto-service:1.0-rc2'
     compile 'com.google.auto:auto-common:0.6'
 
     testCompile 'junit:junit:4.11'


### PR DESCRIPTION
It's only needed at compile time to generate the service file.