### PR TITLE
Remove unused arguments to CodeBlock.of()

### DIFF
--- a/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -594,7 +594,7 @@ public class AutoValueGsonExtension extends AutoValueExtension {
       if (defaultValue != null) {
         return CodeBlock.of("$L", defaultValue);
       } else {
-        return CodeBlock.of("$T.valueOf(null)", field.type, field, field.type.box());
+        return CodeBlock.of("$T.valueOf(null)", field.type);
       }
     }
     if (prop.nullable()) {


### PR DESCRIPTION
I found these while writing an ErrorProne check to identify bad invocations of CodeBlock formatting. I don't know the context of this code, but it seems that the 2nd and 3rd parameters are unused.