### PR TITLE
Implement @GenerateTypeAdapter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,80 @@ android {
 }
 ```
 
+## @GenerateTypeAdapter
+
+There is an annotation in the `auto-value-gson-annotations` artifact called `@GenerateTypeAdapter`. This annotation
+can be set on types to indicate to the extension that you want the generated adapter to be a top level class in the same
+package. The name of this class will be the AutoValue class's name plus `_GsonTypeAdapter` suffix.
+
+Types annotated with this can also be (de)serialized dynamically at runtime with a provided runtime `TypeAdapterFactory`
+implementation in the annotation called `FACTORY`. The type name and generated typeadapter class's name *must not be obfuscated*
+for this to work.
+
+When this annotation is used, there will be no intermediate AutoValue class generated (as opposed to the default logic, 
+which generates an intermediate class and generates the `TypeAdapter` as a static inner class of it).
+
+`@GenerateTypeAdapter` is compatible with the factory approach above, just make your static method's implementation
+point to it. It can also be an alternative to it if you use the runtime factory, particularly if you 
+have a multimodule project and are willing to accept a small amount of (heavily cached) reflection.
+
+The generated class will have the same parameters as if it were the inner class. If it's generic, its constructor
+accepts a `Gson` instance and `TypeToken` of the generics. If it's not generic, it's just a `Gson` instance.
+
+Example usage:
+
+```java
+@GenerateTypeAdapter
+@AutoValue
+public class Foo {
+  // ...
+  public static TypeAdapter<Foo> typeAdapter(Gson gson) {
+    return new Foo_GsonTypeAdapter(gson);
+  }
+}
+
+// Generates
+public final class Foo_GsonTypeAdapter extends TypeAdapter<Foo> {
+  public Foo_GsonTypeAdapter(Gson gson) {
+    //...
+  }
+}
+
+// Or with generics
+@GenerateTypeAdapter
+@AutoValue
+public class Foo<T> {
+  // ...
+  public static TypeAdapter<Foo> typeAdapter(Gson gson, TypeToken<? extends Foo<T>> typeToken) {
+    return new Foo_GsonTypeAdapter(gson, typeToken);
+  }
+}
+
+// Generates
+public final class Foo_GsonTypeAdapter extends TypeAdapter<Foo> {
+  public Foo_GsonTypeAdapter(Gson gson, TypeToken<? extends Foo<T>> typeToken) {
+    //...
+  }
+}
+
+// Using the runtime FACTORY
+new GsonBuilder()
+    .addTypeAdapterFactory(GenerateTypeAdapter.FACTORY)
+    .build()
+    .toJson(myFooInstance);
+```
+
+Proguard rules for obfuscation:
+
+```
+# Retain generated classes that end in the suffix
+-keepnames class **_GsonTypeAdapter
+
+# Prevent obfuscation of types which use @GenerateTypeAdapter since the simple name
+# is used to reflectively look up the generated adapter.
+-keepnames @com.ryanharter.auto.value.gson.GenerateTypeAdapter class *
+```
+
 ## Download
 
 Add a Gradle dependency to the `apt` and `provided` configuration.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Add a Gradle dependency to the `apt` and `provided` configuration.
 
 ```groovy
 annotationProcessor 'com.ryanharter.auto.value:auto-value-gson:0.6.0'
-provided 'com.ryanharter.auto.value:auto-value-gson-annotations:0.6.0'
+compile 'com.ryanharter.auto.value:auto-value-gson-annotations:0.6.0'
 ```
 
 Snapshots of the latest development version are available in [Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/).

--- a/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
+++ b/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
@@ -83,12 +83,12 @@ public @interface GenerateTypeAdapter {
           // Try the gson constructor
           //noinspection unchecked
           adapterCtor =
-              (Constructor<? extends TypeAdapter>) bindingClass.getConstructor(cls, Gson.class);
+              (Constructor<? extends TypeAdapter>) bindingClass.getConstructor(Gson.class);
         } catch (NoSuchMethodException e) {
           // Try the gson + typetoken constructor
           //noinspection unchecked
           adapterCtor =
-              (Constructor<? extends TypeAdapter>) bindingClass.getConstructor(cls, Gson.class,
+              (Constructor<? extends TypeAdapter>) bindingClass.getConstructor(Gson.class,
                   TypeToken.class);
         }
       } catch (ClassNotFoundException e) {

--- a/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
+++ b/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
@@ -9,8 +9,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -27,7 +27,7 @@ public @interface GenerateTypeAdapter {
 
   TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
     private final Map<Class<?>, Constructor<? extends TypeAdapter>> adapters =
-        new LinkedHashMap<>();
+        new ConcurrentHashMap<>();
 
     @SuppressWarnings("unchecked")
     @Override

--- a/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
+++ b/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
@@ -1,7 +1,16 @@
 package com.ryanharter.auto.value.gson;
 
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -11,7 +20,84 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * TypeAdapter in a separate class rather than an inner class of an intermediate AutoValue-generated
  * class hierarchy.
  */
+@Inherited
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface GenerateTypeAdapter {
+
+  TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
+    private final Map<Class<?>, Constructor<? extends TypeAdapter>> adapters =
+        new LinkedHashMap<>();
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+      Class<? super T> rawType = type.getRawType();
+      if (!rawType.isAnnotationPresent(GenerateTypeAdapter.class)) {
+        return null;
+      }
+
+      Constructor<? extends TypeAdapter> constructor = findConstructorForClass(rawType);
+      if (constructor == null) {
+        return null;
+      }
+      //noinspection TryWithIdenticalCatches Resolves to API 19+ only type.
+      try {
+        if (constructor.getParameterCount() == 1) {
+          return constructor.newInstance(gson);
+        } else {
+          return constructor.newInstance(gson, type);
+        }
+      } catch (IllegalAccessException e) {
+        throw new RuntimeException("Unable to invoke " + constructor, e);
+      } catch (InstantiationException e) {
+        throw new RuntimeException("Unable to invoke " + constructor, e);
+      } catch (InvocationTargetException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof RuntimeException) {
+          throw (RuntimeException) cause;
+        }
+        if (cause instanceof Error) {
+          throw (Error) cause;
+        }
+        throw new RuntimeException(
+            "Could not create generated TypeAdapter instance for type " + rawType, cause);
+      }
+    }
+
+    private Constructor<? extends TypeAdapter> findConstructorForClass(Class<?> cls) {
+      Constructor<? extends TypeAdapter> adapterCtor = adapters.get(cls);
+      if (adapterCtor != null) {
+        return adapterCtor;
+      }
+      String clsName = cls.getName();
+      if (clsName.startsWith("android.")
+          || clsName.startsWith("java.")
+          || clsName.startsWith("kotlin.")) {
+        return null;
+      }
+      try {
+        Class<?> bindingClass = cls.getClassLoader()
+            .loadClass(clsName + "_GsonTypeAdapter");
+        try {
+          // Try the gson constructor
+          //noinspection unchecked
+          adapterCtor =
+              (Constructor<? extends TypeAdapter>) bindingClass.getConstructor(cls, Gson.class);
+        } catch (NoSuchMethodException e) {
+          // Try the gson + typetoken constructor
+          //noinspection unchecked
+          adapterCtor =
+              (Constructor<? extends TypeAdapter>) bindingClass.getConstructor(cls, Gson.class,
+                  TypeToken.class);
+        }
+      } catch (ClassNotFoundException e) {
+        adapterCtor = findConstructorForClass(cls.getSuperclass());
+      } catch (NoSuchMethodException e) {
+        throw new RuntimeException("Unable to find binding constructor for " + clsName, e);
+      }
+      adapters.put(cls, adapterCtor);
+      return adapterCtor;
+    }
+  };
 }

--- a/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
+++ b/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
@@ -1,0 +1,17 @@
+package com.ryanharter.auto.value.gson;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotate a given AutoValue-annotated type to indicate to auto-value-gson to generate its
+ * TypeAdapter in a separate class rather than an inner class of an intermediate AutoValue-generated
+ * class hierarchy.
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface GenerateTypeAdapter {
+}

--- a/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessor.java
+++ b/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonAdapterFactoryProcessor.java
@@ -21,7 +21,9 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
@@ -135,15 +137,24 @@ public class AutoValueGsonAdapterFactoryProcessor extends AbstractProcessor {
         .returns(result)
         .addStatement("Class<$T> rawType = (Class<$T>) $N.getRawType()", t, t, type);
 
-    for (int i = 0, elementsSize = elements.size(); i < elementsSize; i++) {
-      Element element = elements.get(i);
+    List<Map.Entry<Element, Optional<ExecutableElement>>> properties = elements.stream()
+        .collect(Collectors.toMap(e -> e, this::getTypeAdapterMethod))
+        .entrySet()
+        .stream()
+        .filter(entry -> entry.getValue().isPresent())
+        .collect(Collectors.toList());
+
+    for (int i = 0, elementsSize = properties.size(); i < elementsSize; i++) {
+      Map.Entry<Element, Optional<ExecutableElement>> entry = properties.get(i);
+      Element element = entry.getKey();
       TypeName elementType = rawType(element);
       if (i == 0) {
         create.beginControlFlow("if ($T.class.isAssignableFrom(rawType))", elementType);
       } else {
         create.nextControlFlow("else if ($T.class.isAssignableFrom(rawType))", elementType);
       }
-      ExecutableElement typeAdapterMethod = getTypeAdapterMethod(element);
+      //noinspection ConstantConditions We've filtered absent ones
+      ExecutableElement typeAdapterMethod = entry.getValue().get();
       List<? extends VariableElement> params = typeAdapterMethod.getParameters();
       if (params != null && params.size() == 1) {
         create.addStatement("return (TypeAdapter<$T>) $T." + typeAdapterMethod.getSimpleName() + "($N)", t, elementType, gson);
@@ -167,7 +178,7 @@ public class AutoValueGsonAdapterFactoryProcessor extends AbstractProcessor {
     return type;
   }
 
-  private ExecutableElement getTypeAdapterMethod(Element element) {
+  private Optional<ExecutableElement> getTypeAdapterMethod(Element element) {
     TypeName type = TypeName.get(element.asType());
     ParameterizedTypeName typeAdapterType = ParameterizedTypeName
         .get(ClassName.get(TypeAdapter.class), type);
@@ -175,7 +186,7 @@ public class AutoValueGsonAdapterFactoryProcessor extends AbstractProcessor {
       if (method.getModifiers().contains(STATIC) && !method.getModifiers().contains(PRIVATE)) {
         TypeName returnType = TypeName.get(method.getReturnType());
         if (returnType.equals(typeAdapterType)) {
-          return method;
+          return Optional.of(method);
         } else if (returnType instanceof ParameterizedTypeName) {
           ParameterizedTypeName paramReturnType = (ParameterizedTypeName) returnType;
           TypeName argument = paramReturnType.typeArguments.get(0);
@@ -184,13 +195,13 @@ public class AutoValueGsonAdapterFactoryProcessor extends AbstractProcessor {
           if (type instanceof ParameterizedTypeName) {
             ParameterizedTypeName pTypeName = (ParameterizedTypeName) type;
             if (pTypeName.rawType.equals(argument)) {
-              return method;
+              return Optional.of(method);
             }
           }
         }
       }
     }
-    return null;
+    return Optional.empty();
   }
 
   private void error(Element element, String message, Object... args) {

--- a/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -254,6 +254,8 @@ public class AutoValueGsonExtension extends AutoValueExtension {
     boolean generatedAnnotationAvailable = context.processingEnvironment()
         .getElementUtils()
         .getTypeElement("javax.annotation.Generated") != null;
+    TypeElement type = context.autoValueClass();
+    boolean generateExternalAdapter = type.getAnnotation(GenerateTypeAdapter.class) != null;
     List<Property> properties = readProperties(context.properties());
 
     Map<String, TypeName> types = convertPropertiesToTypes(context.properties());
@@ -271,28 +273,53 @@ public class AutoValueGsonExtension extends AutoValueExtension {
       superclasstype = ParameterizedTypeName.get(ClassName.get(context.packageName(), classToExtend), params.toArray(new TypeName[params.size()]));
     }
 
-    TypeSpec typeAdapter = createTypeAdapter(context, classNameClass, autoValueClass, properties, params);
+    ClassName adapterClassName = generateExternalAdapter
+        ? ClassName.get(context.packageName(), autoValueClass.simpleName() + "_GsonTypeAdapter")
+        : classNameClass.nestedClass("GsonTypeAdapter");
+    TypeSpec typeAdapter = createTypeAdapter(context, classNameClass, autoValueClass, adapterClassName, properties, params);
 
-    TypeSpec.Builder subclass = TypeSpec.classBuilder(classNameClass)
-        .superclass(superclasstype)
-        .addType(typeAdapter)
-        .addMethod(generateConstructor(properties, types));
-
-    if (generatedAnnotationAvailable) {
-      subclass.addAnnotation(GENERATED);
-    }
-
-    if (!typeParams.isEmpty()) {
-      subclass.addTypeVariables(params);
-    }
-
-    if (isFinal) {
-      subclass.addModifiers(FINAL);
+    if (generateExternalAdapter) {
+      try {
+        TypeSpec.Builder builder = typeAdapter.toBuilder();
+        if (generatedAnnotationAvailable) {
+          builder.addAnnotation(GENERATED);
+        }
+        JavaFile.builder(context.packageName(), builder.build())
+            .skipJavaLangImports(true)
+            .build()
+            .writeTo(context.processingEnvironment().getFiler());
+      } catch (IOException e) {
+        context.processingEnvironment().getMessager()
+            .printMessage(Diagnostic.Kind.ERROR,
+                String.format(
+                    "Failed to write external TypeAdapter for element \"%s\" with reason \"%s\"",
+                    type,
+                    e.getMessage()));
+      }
+      return null;
     } else {
-      subclass.addModifiers(ABSTRACT);
-    }
+      TypeSpec.Builder subclass = TypeSpec.classBuilder(classNameClass)
+          .superclass(superclasstype)
+          .addType(typeAdapter.toBuilder()
+              .addModifiers(STATIC)
+              .build())
+          .addMethod(generateConstructor(properties, types));
 
-    return JavaFile.builder(context.packageName(), subclass.build()).build().toString();
+      if (generatedAnnotationAvailable) {
+        subclass.addAnnotation(GENERATED);
+      }
+
+      if (!typeParams.isEmpty()) {
+        subclass.addTypeVariables(params);
+      }
+
+      if (isFinal) {
+        subclass.addModifiers(FINAL);
+      } else {
+        subclass.addModifiers(ABSTRACT);
+      }
+      return JavaFile.builder(context.packageName(), subclass.build()).build().toString();
+    }
   }
 
   public List<Property> readProperties(Map<String, ExecutableElement> properties) {
@@ -414,7 +441,12 @@ public class AutoValueGsonExtension extends AutoValueExtension {
     return types;
   }
 
-  public TypeSpec createTypeAdapter(Context context, ClassName className, ClassName autoValueClassName, List<Property> properties, List<TypeVariableName> typeParams) {
+  public TypeSpec createTypeAdapter(Context context,
+      ClassName className,
+      ClassName autoValueClassName,
+      ClassName gsonTypeAdapterName,
+      List<Property> properties,
+      List<TypeVariableName> typeParams) {
     ClassName typeAdapterClass = ClassName.get(TypeAdapter.class);
     TypeName autoValueTypeName = autoValueClassName;
     if (!typeParams.isEmpty()) {
@@ -483,11 +515,9 @@ public class AutoValueGsonExtension extends AutoValueExtension {
       initializedFields.add(field);
     }
 
-    ClassName gsonTypeAdapterName = className.nestedClass("GsonTypeAdapter");
-
     TypeSpec.Builder classBuilder = TypeSpec.classBuilder(gsonTypeAdapterName)
         .addTypeVariables(typeParams)
-        .addModifiers(PUBLIC, STATIC, FINAL)
+        .addModifiers(PUBLIC, FINAL)
         .superclass(superClass)
         .addFields(adapters.values())
         .addMethod(constructor.build())

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     apt 'com.google.auto.value:auto-value:1.4.1'
     apt project(':auto-value-gson')
     compileOnly project(':auto-value-gson')
+    compile project(':auto-value-gson-annotations')
 
     testCompile 'junit:junit:4.12'
     testCompileOnly 'com.google.auto.value:auto-value:1.5.2'

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/WebResponse.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/WebResponse.java
@@ -7,8 +7,7 @@ import com.google.gson.reflect.TypeToken;
 import java.util.List;
 import java.util.Map;
 
-@AutoValue
-public abstract class WebResponse<T> {
+@AutoValue public abstract class WebResponse<T> {
   public abstract int status();
   public abstract T data();
   public abstract List<T> dataList();

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/WebResponse.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/WebResponse.java
@@ -4,8 +4,6 @@ import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
-
-import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 import java.util.List;
 import java.util.Map;
 

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/WebResponse.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/WebResponse.java
@@ -5,16 +5,19 @@ import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
 
+import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 import java.util.List;
 import java.util.Map;
 
-@AutoValue public abstract class WebResponse<T> {
+@AutoValue
+@GenerateTypeAdapter
+public abstract class WebResponse<T> {
   public abstract int status();
   public abstract T data();
   public abstract List<T> dataList();
   public abstract Map<String, List<T>> dataMap();
 
   public static <T> TypeAdapter<WebResponse<T>> typeAdapter(Gson gson, TypeToken<? extends WebResponse<T>> typeToken) {
-    return new AutoValue_WebResponse.GsonTypeAdapter(gson, typeToken);
+    return new WebResponse_GsonTypeAdapter(gson, typeToken);
   }
 }

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/WebResponseNoStatic.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/WebResponseNoStatic.java
@@ -4,19 +4,15 @@ import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;
-
 import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 import java.util.List;
 import java.util.Map;
 
 @AutoValue
-public abstract class WebResponse<T> {
+@GenerateTypeAdapter
+public abstract class WebResponseNoStatic<T> {
   public abstract int status();
   public abstract T data();
   public abstract List<T> dataList();
   public abstract Map<String, List<T>> dataMap();
-
-  public static <T> TypeAdapter<WebResponse<T>> typeAdapter(Gson gson, TypeToken<? extends WebResponse<T>> typeToken) {
-    return new AutoValue_WebResponse.GsonTypeAdapter(gson, typeToken);
-  }
 }

--- a/example/src/test/java/com/ryanharter/auto/value/gson/example/WebResponseTest.java
+++ b/example/src/test/java/com/ryanharter/auto/value/gson/example/WebResponseTest.java
@@ -3,6 +3,7 @@ package com.ryanharter.auto.value.gson.example;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
+import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
 import java.lang.reflect.Type;
 import org.junit.Test;
 
@@ -32,6 +33,38 @@ public class WebResponseTest {
         "\"dataMap\":{\"key\":[{\"firstname\":\"Ryan\",\"lastname\":\"Harter\"}]}}";
     Gson gson = new GsonBuilder()
         .registerTypeAdapterFactory(SampleAdapterFactory.create())
+        .create();
+    Type responseType = new TypeToken<WebResponse<User>>(){}.getType();
+    WebResponse<User> response = gson.fromJson(json, responseType);
+
+    User expected = User.with("Ryan", "Harter");
+    assertEquals(expected, response.data());
+    assertEquals(expected, response.dataList().get(0));
+    assertEquals(expected, response.dataMap().get("key").get(0));
+  }
+
+  @Test public void handlesBasicTypesExternalAdapter() {
+    String json = "{\"status\":200,\"data\":\"string\"," +
+        "\"dataList\":[\"string\"]," +
+        "\"dataMap\":{\"key\":[\"string\"]}}";
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapterFactory(GenerateTypeAdapter.FACTORY)
+        .create();
+    Type responseType = new TypeToken<WebResponse<String>>(){}.getType();
+    WebResponse<String> response = gson.fromJson(json, responseType);
+
+    assertEquals("string", response.data());
+    assertEquals("string", response.dataList().get(0));
+    assertEquals("string", response.dataMap().get("key").get(0));
+    assertEquals(200, response.status());
+  }
+
+  @Test public void handlesComplexTypesExternalAdapter() {
+    String json = "{\"status\":200,\"data\":{\"firstname\":\"Ryan\",\"lastname\":\"Harter\"}, " +
+        "\"dataList\":[{\"firstname\":\"Ryan\",\"lastname\":\"Harter\"}]," +
+        "\"dataMap\":{\"key\":[{\"firstname\":\"Ryan\",\"lastname\":\"Harter\"}]}}";
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapterFactory(GenerateTypeAdapter.FACTORY)
         .create();
     Type responseType = new TypeToken<WebResponse<User>>(){}.getType();
     WebResponse<User> response = gson.fromJson(json, responseType);

--- a/example/src/test/java/com/ryanharter/auto/value/gson/example/WebResponseTest.java
+++ b/example/src/test/java/com/ryanharter/auto/value/gson/example/WebResponseTest.java
@@ -49,9 +49,10 @@ public class WebResponseTest {
         "\"dataMap\":{\"key\":[\"string\"]}}";
     Gson gson = new GsonBuilder()
         .registerTypeAdapterFactory(GenerateTypeAdapter.FACTORY)
+        .registerTypeAdapterFactory(SampleAdapterFactory.create())
         .create();
-    Type responseType = new TypeToken<WebResponse<String>>(){}.getType();
-    WebResponse<String> response = gson.fromJson(json, responseType);
+    Type responseType = new TypeToken<WebResponseNoStatic<String>>(){}.getType();
+    WebResponseNoStatic<String> response = gson.fromJson(json, responseType);
 
     assertEquals("string", response.data());
     assertEquals("string", response.dataList().get(0));
@@ -65,9 +66,10 @@ public class WebResponseTest {
         "\"dataMap\":{\"key\":[{\"firstname\":\"Ryan\",\"lastname\":\"Harter\"}]}}";
     Gson gson = new GsonBuilder()
         .registerTypeAdapterFactory(GenerateTypeAdapter.FACTORY)
+        .registerTypeAdapterFactory(SampleAdapterFactory.create())
         .create();
-    Type responseType = new TypeToken<WebResponse<User>>(){}.getType();
-    WebResponse<User> response = gson.fromJson(json, responseType);
+    Type responseType = new TypeToken<WebResponseNoStatic<User>>(){}.getType();
+    WebResponseNoStatic<User> response = gson.fromJson(json, responseType);
 
     User expected = User.with("Ryan", "Harter");
     assertEquals(expected, response.data());


### PR DESCRIPTION
This implemented support for `@GenerateTypeAdapter`, which is an annotation that can be used to indicate that the developer wants the generated typeadapater to be generated as a top-level class in the same package. This also includes a runtime reflective typeadapterfactory (loosely based on Jake's AutoGson + Butter Knife's lookup logic).

What this means is that you can now trigger generation with this annotation OR a static TypeAdapter-returning method.

You can use both a static method and the annotation, but if you do, the static method implementation will need to point to the public top-level class.

If the annotation is present, no intermediary AutoValue class will be generated either.

The adapter lookups are cached similar to how Butter Knife's bindings are cached.

The runtime factory is intended to be an alternative to generating a factory at the cost of a little (aforementioned cached) reflection. The benefit is that if you have a huge multi-module repo, you don't have to manually manage wiring up generated factories to some top level gson instance.