### PR TITLE
Fix usage of java 8 API in GenerateTypeAdapter

### DIFF
--- a/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
+++ b/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
@@ -43,7 +43,7 @@ public @interface GenerateTypeAdapter {
       }
       //noinspection TryWithIdenticalCatches Resolves to API 19+ only type.
       try {
-        if (constructor.getParameterCount() == 1) {
+        if (constructor.getParameterTypes().length == 1) {
           return constructor.newInstance(gson);
         } else {
           return constructor.newInstance(gson, type);


### PR DESCRIPTION
parameterCount is a java 8 API. Perhaps as a sign of the times, no one's reported it yet and I never ran into it in testing. A little annoyed my IDE didn't lint it either though