### PR TITLE
Switch from ConcurrentHashMap to Collections.synchronizedMap() in GenerateTypeAdapter

### DIFF
--- a/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
+++ b/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
@@ -9,8 +9,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -27,7 +28,7 @@ public @interface GenerateTypeAdapter {
 
   TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
     private final Map<Class<?>, Constructor<? extends TypeAdapter>> adapters =
-        new ConcurrentHashMap<>();
+        Collections.synchronizedMap(new HashMap<>());
 
     @SuppressWarnings("unchecked")
     @Override

--- a/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
+++ b/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
@@ -28,7 +28,7 @@ public @interface GenerateTypeAdapter {
 
   TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
     private final Map<Class<?>, Constructor<? extends TypeAdapter>> adapters =
-        Collections.synchronizedMap(new HashMap<>());
+        Collections.synchronizedMap(new HashMap<Class<?>, Constructor<? extends TypeAdapter>>());
 
     @SuppressWarnings("unchecked")
     @Override

--- a/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
+++ b/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static java.lang.annotation.ElementType.TYPE;
@@ -28,7 +28,8 @@ public @interface GenerateTypeAdapter {
 
   TypeAdapterFactory FACTORY = new TypeAdapterFactory() {
     private final Map<Class<?>, Constructor<? extends TypeAdapter>> adapters =
-        Collections.synchronizedMap(new HashMap<Class<?>, Constructor<? extends TypeAdapter>>());
+        Collections.synchronizedMap(
+            new LinkedHashMap<Class<?>, Constructor<? extends TypeAdapter>>());
 
     @SuppressWarnings("unchecked")
     @Override


### PR DESCRIPTION
ConcurrentHashMap bugs on some versions of android: https://code.google.com/p/android/issues/detail?id=170073