### PR TITLE
Revert "Add compatilibity to java 1.7"

### DIFF
--- a/auto-value-gson/build.gradle
+++ b/auto-value-gson/build.gradle
@@ -3,8 +3,8 @@ import org.gradle.internal.jvm.Jvm
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
     api project(':auto-value-gson-annotations')


### PR DESCRIPTION
This reverts commit 2a7275f78aee0b5bb49fcfe88274ee2831e65014.

Only auto-value-gson-annotations needs to be JDK7-compatible.