### PR TITLE
#164 Use correct "Generated"-annotation based on JDK version.

### DIFF
--- a/auto-value-gson/build.gradle
+++ b/auto-value-gson/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     api 'com.google.auto.value:auto-value:1.6'
     api 'com.google.auto.value:auto-value-annotations:1.6'
     compileOnly 'com.google.auto.service:auto-service:1.0-rc3'
-    api 'com.google.auto:auto-common:0.8'
+    api 'com.google.auto:auto-common:0.9'
 
     testCompile 'junit:junit:4.12'
     testCompile 'com.google.truth:truth:0.36'


### PR DESCRIPTION
Fixes usage of auto-value-gson with JDK 9 and newer.

This bumps the dependency of auto-common to 0.9, because this version includes the necessary utility method.