### PR TITLE
Clean up Ignore logic a bit

### DIFF
--- a/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/Ignore.java
+++ b/auto-value-gson-annotations/src/main/java/com/ryanharter/auto/value/gson/Ignore.java
@@ -27,15 +27,6 @@ public @interface Ignore {
      */
     SERIALIZATION,
     /**
-     * Ignore this field for deserialization only. The annotated property will be ignored by the
-     * generated Gson TypeAdapter when creating an object from JSON, and instead the default value
-     * for this property will be used.
-     * <p>
-     * If this field is not marked as nullable, a default value must be supplied to the generated
-     * TypeAdapter's constructor.
-     */
-    DESERIALIZATION,
-    /**
      * Ignore this field for both serialization and deserialization.
      * <p>
      * If this field is not marked as nullable, a default value must be supplied to the generated
@@ -43,6 +34,15 @@ public @interface Ignore {
      * <p>
      * This is the default value for the Ignore annotation.
      */
-    BOTH
+    BOTH,
+    /**
+     * Ignore this field for deserialization only. The annotated property will be ignored by the
+     * generated Gson TypeAdapter when creating an object from JSON, and instead the default value
+     * for this property will be used.
+     * <p>
+     * If this field is not marked as nullable, a default value must be supplied to the generated
+     * TypeAdapter's constructor.
+     */
+    DESERIALIZATION
   }
 }

--- a/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -358,7 +358,7 @@ public class AutoValueGsonExtension extends AutoValueExtension {
     Set<TypeName> seenTypes = Sets.newHashSet();
     NameAllocator nameAllocator = new NameAllocator();
     for (Property property : properties) {
-      if (!property.shouldNotDeserialize() && !property.shouldNotSerialize()) {
+      if (property.shouldNotDeserialize() && property.shouldNotSerialize()) {
         continue;
       }
       TypeName type = property.type.isPrimitive() ? property.type.box() : property.type;

--- a/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -358,7 +358,7 @@ public class AutoValueGsonExtension extends AutoValueExtension {
     Set<TypeName> seenTypes = Sets.newHashSet();
     NameAllocator nameAllocator = new NameAllocator();
     for (Property property : properties) {
-      if (property.shouldNotDeserialize() && !property.shouldNotSerialize()) {
+      if (!property.shouldNotDeserialize() && !property.shouldNotSerialize()) {
         continue;
       }
       TypeName type = property.type.isPrimitive() ? property.type.box() : property.type;


### PR DESCRIPTION
Relates to #48, but I can't repro any issue described there and think it may just be old. This improves it a bit by not always inverting the serialization checks.

I do plan to just use a shared transient annotation library for this in a separate PR, but this should make switching to that easy