### PR TITLE
Embed proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,9 +187,9 @@ new GsonBuilder()
 
 ### R8 / ProGuard
 
-If you are using R8 or ProGuard add the options from [this file](https://github.com/rharter/auto-value-gson/blob/master/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro). If using Android, this requires Android Gradle Plugin 3.2.0+.
+If you are using R8 or ProGuard add the options from [this file](https://github.com/rharter/auto-value-gson/blob/master/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro).
 
-On Proguard 6.1+ or R8, these rules will be automatically detected.
+If using Android, Android Gradle Plugin 3.3.0+, these rules will automatically be detected.
 
 ## Download
 

--- a/README.md
+++ b/README.md
@@ -185,16 +185,13 @@ new GsonBuilder()
     .toJson(myFooInstance);
 ```
 
-Proguard rules for obfuscation:
 
-```
-# Retain generated classes that end in the suffix
--keepnames class **_GsonTypeAdapter
 
-# Prevent obfuscation of types which use @GenerateTypeAdapter since the simple name
-# is used to reflectively look up the generated adapter.
--keepnames @com.ryanharter.auto.value.gson.GenerateTypeAdapter class *
-```
+### R8 / ProGuard:
+
+If you are using R8 or ProGuard add the options from [this file](https://github.com/rharter/auto-value-gson/blob/master/moshi/src/main/resources/META-INF/proguard/moshi.pro). If using Android, this requires Android Gradle Plugin 3.2.0+.
+
+On Proguard 6.1+ or R8, these rules will be automatically detected.
 
 ## Download
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ new GsonBuilder()
 
 ### R8 / ProGuard
 
-If you are using R8 or ProGuard add the options from [this file](https://github.com/rharter/auto-value-gson/blob/master/moshi/src/main/resources/META-INF/proguard/autovaluegson.pro). If using Android, this requires Android Gradle Plugin 3.2.0+.
+If you are using R8 or ProGuard add the options from [this file](https://github.com/rharter/auto-value-gson/blob/master/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro). If using Android, this requires Android Gradle Plugin 3.2.0+.
 
 On Proguard 6.1+ or R8, these rules will be automatically detected.
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ new GsonBuilder()
 
 ### R8 / ProGuard:
 
-If you are using R8 or ProGuard add the options from [this file](https://github.com/rharter/auto-value-gson/blob/master/moshi/src/main/resources/META-INF/proguard/moshi.pro). If using Android, this requires Android Gradle Plugin 3.2.0+.
+If you are using R8 or ProGuard add the options from [this file](https://github.com/rharter/auto-value-gson/blob/master/moshi/src/main/resources/META-INF/proguard/autovaluegson.pro). If using Android, this requires Android Gradle Plugin 3.2.0+.
 
 On Proguard 6.1+ or R8, these rules will be automatically detected.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ new GsonBuilder()
 
 If you are using R8 or ProGuard add the options from [this file](https://github.com/rharter/auto-value-gson/blob/master/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro).
 
-If using Android, Android Gradle Plugin 3.3.0+, these rules will automatically be detected.
+If using Android, Android Gradle Plugin 3.3.0+, these rules will automatically be detected. Note that at the time of writing, there is a bug and you should follow steps [here](https://github.com/square/moshi/issues/738#issuecomment-453024615).
 
 ## Download
 

--- a/README.md
+++ b/README.md
@@ -25,24 +25,6 @@ annotated class returning a TypeAdapter.  You can also annotate your properties 
 }
 ```
 
-Additionally, you can set custom default values. This is disabled by default. See [Compiler options](#compiler-options) on how to enable this.
-
-```java
-@AutoValue public abstract class Foo {
-  abstract String bar();
-  @SerializedName("Baz") abstract String baz();
-  abstract int quux();
-  abstract String with_underscores();
-
-  public static TypeAdapter<Foo> typeAdapter(Gson gson) {
-    return new AutoValue_Foo.GsonTypeAdapter(gson)
-      // You can set custom default values
-      .setDefaultQuux(4711)
-      .setDefaultWith_underscores("");
-  }
-}
-```
-
 Now build your project and de/serialize your Foo.
 
 ## The TypeAdapter

--- a/README.md
+++ b/README.md
@@ -185,9 +185,7 @@ new GsonBuilder()
     .toJson(myFooInstance);
 ```
 
-
-
-### R8 / ProGuard:
+### R8 / ProGuard
 
 If you are using R8 or ProGuard add the options from [this file](https://github.com/rharter/auto-value-gson/blob/master/moshi/src/main/resources/META-INF/proguard/autovaluegson.pro). If using Android, this requires Android Gradle Plugin 3.2.0+.
 
@@ -197,18 +195,12 @@ On Proguard 6.1+ or R8, these rules will be automatically detected.
 
 Add a Gradle dependency to the `apt` and `provided` configuration.
 
-```groovy
-annotationProcessor 'com.ryanharter.auto.value:auto-value-gson:0.8.0'
-compile 'com.ryanharter.auto.value:auto-value-gson-runtime:0.8.0'
+```kotlin
+annotationProcessor("com.ryanharter.auto.value:auto-value-gson:0.8.0")
+implementation("com.ryanharter.auto.value:auto-value-gson-runtime:0.8.0")
 ```
 
 Snapshots of the latest development version are available in [Sonatype's `snapshots` repository](https://oss.sonatype.org/content/repositories/snapshots/).
-
-You will also need a normal runtime dependency for gson itself.
-
-```groovy
-compile 'com.google.code.gson:gson:2.8.0'
-```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,29 @@ new GsonBuilder()
 
 If you are using R8 or ProGuard add the options from [this file](https://github.com/rharter/auto-value-gson/blob/master/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro).
 
-If using Android, Android Gradle Plugin 3.3.0+, these rules will automatically be detected. Note that at the time of writing, there is a bug and you should follow steps [here](https://github.com/square/moshi/issues/738#issuecomment-453024615).
+#### If using Android
+
+Android Gradle Plugin 3.3.0+ will automatically extract these rules. Note that for proguard support, you must use ProGuard 6.1.0beta2 or later.
+
+Set `android.proguard.enableRulesExtraction=false` and then copy the proguard rules to your project like described above.
+
+OR
+
+Upgrade proguard to 6.1.0beta2:
+
+```groovy
+buildscript {
+    configurations.all {
+        resolutionStrategy {
+            force 'net.sf.proguard:proguard-gradle:6.1.0beta2'
+        }
+    }
+}
+```
+
+OR
+
+Enable R8 by setting `android.enableR8=true`.
 
 ## Download
 

--- a/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro
+++ b/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro
@@ -1,0 +1,35 @@
+# Annotations are for embedding static analysis information.
+-dontwarn org.jetbrains.annotations.**
+-dontwarn com.google.errorprone.annotations;.**
+
+# Retain generated TypeAdapters if annotated type is retained.
+-if @com.ryanharter.auto.value.gson.GenerateTypeAdapter class *
+-keep class <1>_GsonTypeAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.ryanharter.auto.value.gson.GenerateTypeAdapter class **$*
+-keep class <1>_<2>_GsonTypeAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.ryanharter.auto.value.gson.GenerateTypeAdapter class **$*$*
+-keep class <1>_<2>_<3>_GsonTypeAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.ryanharter.auto.value.gson.GenerateTypeAdapter class **$*$*$*
+-keep class <1>_<2>_<3>_<4>_GsonTypeAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.ryanharter.auto.value.gson.GenerateTypeAdapter class **$*$*$*$*
+-keep class <1>_<2>_<3>_<4>_<5>_GsonTypeAdapter {
+    <init>(...);
+    <fields>;
+}
+-if @com.ryanharter.auto.value.gson.GenerateTypeAdapter class **$*$*$*$*$*
+-keep class <1>_<2>_<3>_<4>_<5>_<6>_GsonTypeAdapter {
+    <init>(...);
+    <fields>;
+}

--- a/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro
+++ b/auto-value-gson-runtime/src/main/resources/META-INF/proguard/autovaluegson.pro
@@ -1,6 +1,6 @@
 # Annotations are for embedding static analysis information.
 -dontwarn org.jetbrains.annotations.**
--dontwarn com.google.errorprone.annotations;.**
+-dontwarn com.google.errorprone.annotations.**
 
 # Retain generated TypeAdapters if annotated type is retained.
 -if @com.ryanharter.auto.value.gson.GenerateTypeAdapter class *


### PR DESCRIPTION
This embeds proguard rules directly in the jar for R8/proguard, and also tunes them to use newer features to only selectively keep adapters (adapted from Moshi's configuration)

Resolves #200