### PR TITLE
Fix factory method with generics

### DIFF
--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/GenericsExample.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/GenericsExample.java
@@ -11,6 +11,18 @@ import java.lang.reflect.Type;
   public abstract B b();
   public abstract C c();
 
+  @AutoValue.Builder
+  public interface Builder<A, B, C> {
+    Builder<A, B, C> a(A a);
+    Builder<A, B, C> b(B b);
+    Builder<A, B, C> c(C c);
+    GenericsExample<A, B, C> build();
+  }
+
+  public static <A, B, C> Builder<A, B, C> builder() {
+    return new AutoValue_GenericsExample.Builder<A, B, C>();
+  }
+
   public static <A, B, C> TypeAdapter<GenericsExample<A, B, C>> typeAdapter(Gson gson,
       Type[] types) {
     return new AutoValue_GenericsExample.GsonTypeAdapter<>(gson, types);


### PR DESCRIPTION
Fixes #226.

Invalid java code was being generated when trying to instantiate a builder with generics via its factory method inside the `TypeAdapter#read`.

The fix is to use the builder's type rather than class when declaring the builder field inside of `TypeAdapter#read`.

I've also updated `GenericsExample` to show that it works and to serve as a test. The read method generated now looks like.

```java
public GenericsExample<A, B, C> read(JsonReader jsonReader) throws IOException {
  if (jsonReader.peek() == JsonToken.NULL) {
    jsonReader.nextNull();
    return null;
   }
   jsonReader.beginObject();
   GenericsExample.Builder<A, B, C> builder = GenericsExample.builder();
   ...
}
```