### PR TITLE
Optimize hierarchy lookups for GenerateTypeAdapter

### DIFF
--- a/auto-value-gson-runtime/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
+++ b/auto-value-gson-runtime/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
@@ -42,6 +42,13 @@ public @interface GenerateTypeAdapter {
         return null;
       }
 
+      Class<?> superClass = rawType.getSuperclass();
+      if (superClass.isAnnotationPresent(GenerateTypeAdapter.class)) {
+        // We might be a generated AutoValue_ subtype. Walk up until we hit the first class that
+        // isn't annotated with GenerateTypeAdapter.
+        return (TypeAdapter<T>) gson.getAdapter(superClass);
+      }
+
       Constructor<? extends TypeAdapter> constructor = findConstructorForClass(rawType);
       if (constructor == null) {
         return null;

--- a/auto-value-gson-runtime/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
+++ b/auto-value-gson-runtime/src/main/java/com/ryanharter/auto/value/gson/GenerateTypeAdapter.java
@@ -89,8 +89,9 @@ public @interface GenerateTypeAdapter {
         return null;
       }
       try {
+        String nameAdjusted = cls.getName().replace("$", "_");
         Class<?> bindingClass = cls.getClassLoader()
-            .loadClass(clsName + "_GsonTypeAdapter");
+            .loadClass(nameAdjusted + "_GsonTypeAdapter");
         try {
           // Try the gson constructor
           //noinspection unchecked

--- a/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/auto-value-gson/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -253,7 +253,7 @@ public class AutoValueGsonExtension extends AutoValueExtension {
     }
 
     ClassName adapterClassName = generateExternalAdapter
-        ? ClassName.get(context.packageName(), autoValueClass.simpleName() + "_GsonTypeAdapter")
+        ? ClassName.get(context.packageName(), Joiner.on("_").join(autoValueClass.simpleNames()) + "_GsonTypeAdapter")
         : classNameClass.nestedClass("GsonTypeAdapter");
     ClassName finalSuperClass = generateExternalAdapter ? classNameClass : superclassRawType;
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -12,5 +12,6 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testAnnotationProcessor 'com.google.auto.value:auto-value:1.7'
+    testAnnotationProcessor project(':auto-value-gson')
     testCompileOnly 'com.google.auto.value:auto-value-annotations:1.7'
 }

--- a/example/src/test/java/com/ryanharter/auto/value/gson/example/GenerateTypeAdapterTest.java
+++ b/example/src/test/java/com/ryanharter/auto/value/gson/example/GenerateTypeAdapterTest.java
@@ -1,0 +1,63 @@
+package com.ryanharter.auto.value.gson.example;
+
+import com.google.auto.value.AutoValue;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.TypeAdapter;
+import com.ryanharter.auto.value.gson.GenerateTypeAdapter;
+import java.io.IOException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public final class GenerateTypeAdapterTest {
+
+  @Test
+  public void smokeTest() throws IOException {
+    //language=JSON
+    String json = "{\"seasoning\":\"spicy\"}";
+    Gson gson = new GsonBuilder()
+        .registerTypeAdapterFactory(GenerateTypeAdapter.FACTORY)
+        .create();
+
+    Taco expectedTaco = Taco.create("spicy");
+
+    // Basic read
+    Taco taco = gson.fromJson(json, Taco.class);
+    assertEquals(expectedTaco, taco);
+
+    // Basic write
+    String encoded = gson.toJson(taco);
+    assertEquals(json, encoded);
+
+    // The same as above, but with the adapter looked up first
+    TypeAdapter<Taco> adapter = gson.getAdapter(Taco.class);
+
+    // Basic read
+    Taco taco2 = adapter.fromJson(json);
+    assertEquals(expectedTaco, taco2);
+
+    // Basic write
+    String encoded2 = adapter.toJson(taco);
+    assertEquals(json, encoded2);
+
+    // Ensure the generated AutoValue_Taco class still gets translated back into a taco adapter
+    // Assert they're the same to ensure we've properly delegated up the gson chain and avoid
+    // duplicating adapter instances.
+    TypeAdapter<AutoValue_GenerateTypeAdapterTest_Taco> generatedClassAdapter = gson.getAdapter(AutoValue_GenerateTypeAdapterTest_Taco.class);
+    assertSame(adapter, generatedClassAdapter);
+  }
+
+  @GenerateTypeAdapter
+  @AutoValue
+  public static abstract class Taco {
+
+    public abstract String seasoning();
+
+    public static Taco create(String seasoning) {
+      return new AutoValue_GenerateTypeAdapterTest_Taco(seasoning);
+    }
+
+  }
+}


### PR DESCRIPTION
This allows for reuse of adapters as well as a faster traversal rather than the reflective fall-through. Before - it would try the whole constructor lookup before trying to walk up to the superclass as a stop-gap and also potentially create duplicate adapters in Moshi's cache.

This also revealed in testing that GenerateTypeAdapter didn't support nested types, which are fixed opportunistically here using Moshi's naming scheme.