### PR TITLE
Use reflection name in proguardNameOf()

### DIFF
--- a/auto-value-gson-extension/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/auto-value-gson-extension/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -984,11 +984,11 @@ public class AutoValueGsonExtension extends AutoValueExtension {
 
   private static String proguardNameOf(TypeName typeName) {
     if (typeName instanceof ClassName) {
-      return ((ClassName) typeName).canonicalName();
+      return ((ClassName) typeName).reflectionName();
     } else if (typeName instanceof ArrayTypeName) {
       return proguardNameOf(((ArrayTypeName) typeName).componentType) + "[]";
     } else if (typeName instanceof ParameterizedTypeName) {
-      return ((ParameterizedTypeName) typeName).rawType.canonicalName();
+      return ((ParameterizedTypeName) typeName).rawType.reflectionName();
     } else if (typeName instanceof TypeVariableName) {
       return "java.lang.Object";
     } else {


### PR DESCRIPTION
Wasn't actually an issue in practice since none of the types we pass into this are nested types, but good hygiene