### PR TITLE
Add mechanism for opting in custom classes to factory generation

### DIFF
--- a/auto-value-gson-factory/src/test/java/com/ryanharter/auto/value/gson/factory/AutoValueGsonAdapterFactoryProcessorTest.java
+++ b/auto-value-gson-factory/src/test/java/com/ryanharter/auto/value/gson/factory/AutoValueGsonAdapterFactoryProcessorTest.java
@@ -484,8 +484,8 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
       .that(ImmutableSet.of(source1, factorySource))
       .processedWith(new AutoValueGsonAdapterFactoryProcessor())
       .failsToCompile()
-      .withErrorContaining("no @AutoValue-annotated elements were found on the "
-          + "compilation classpath");
+      .withErrorContaining("no @AutoValue-annotated or "
+          + "@ExposeToGsonTypeAdapterFactory elements were found on the compilation classpath");
   }
 
   @Test public void noAutoValueModelsWithAdapterMethods_shouldError() {

--- a/auto-value-gson-factory/src/test/java/com/ryanharter/auto/value/gson/factory/AutoValueGsonAdapterFactoryProcessorTest.java
+++ b/auto-value-gson-factory/src/test/java/com/ryanharter/auto/value/gson/factory/AutoValueGsonAdapterFactoryProcessorTest.java
@@ -95,6 +95,19 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
         + "  }\n"
         + "  public abstract String getName();\n"
         + "}");
+    // Exposed to factory but isn't an auto-value-gson-extension user
+    JavaFileObject exposedToAdapterFactory = JavaFileObjects.forSourceString("test.Exposed", ""
+        + "package test;\n"
+        + "import com.google.auto.value.AutoValue;\n"
+        + "import com.google.gson.TypeAdapter;\n"
+        + "import com.ryanharter.auto.value.gson.ExposeToGsonTypeAdapterFactory;\n"
+        + "@ExposeToGsonTypeAdapterFactory\n"
+        + "public abstract class Exposed {\n"
+        + "  public static TypeAdapter<Exposed> typeAdapter() {\n"
+        + "    return null;\n"
+        + "  }\n"
+        + "  public abstract String getName();\n"
+        + "}");
     JavaFileObject factorySource = JavaFileObjects.forSourceString("test.MyAdapterFactory", ""
         + "package test;\n"
         + "import com.google.gson.TypeAdapterFactory;\n"
@@ -132,6 +145,8 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
         + "      return (TypeAdapter<T>) Foo.typeAdapter(gson);\n"
         + "    } else if (PublicInOtherPackage.class.isAssignableFrom(rawType)) {\n"
         + "      return (TypeAdapter<T>) PublicInOtherPackage.typeAdapter(gson);\n"
+        + "    } else if (Exposed.class.isAssignableFrom(rawType)) {\n"
+        + "      return (TypeAdapter<T>) Exposed.typeAdapter();\n"
         + "    } else {\n"
         + "      return null;\n"
         + "    }\n"
@@ -139,7 +154,7 @@ public class AutoValueGsonAdapterFactoryProcessorTest {
         + "}");
 
     assertAbout(javaSources())
-        .that(ImmutableSet.of(fooSource, barSource, bazSource, publicInOtherPackage, notVisibleClass, notVisibleMethod, privateMethod, factorySource))
+        .that(ImmutableSet.of(fooSource, barSource, bazSource, publicInOtherPackage, notVisibleClass, notVisibleMethod, privateMethod, exposedToAdapterFactory, factorySource))
         .processedWith(new AutoValueGsonAdapterFactoryProcessor())
         .compilesWithoutError()
         .and()

--- a/auto-value-gson-runtime/src/main/java/com/ryanharter/auto/value/gson/ExposeToGsonTypeAdapterFactory.java
+++ b/auto-value-gson-runtime/src/main/java/com/ryanharter/auto/value/gson/ExposeToGsonTypeAdapterFactory.java
@@ -1,0 +1,30 @@
+package com.ryanharter.auto.value.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Type;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * Annotation to indicate that a given class should be included in a {@link GsonTypeAdapterFactory GsonTypeAdapterFactory-annotated}
+ * factory in this compilation unit if it doesn't use the Auto-Value-Gson extension. This can be
+ * useful for classes that use custom adapters but you still want included in the generated factory.
+ * <p>
+ * Like classes that do use the Auto-Value-Gson extension, these classes must implement a static
+ * {@link TypeAdapter TypeAdapter-returning} method that contains one of the following parameters
+ * combinations:
+ * <p>
+ * <ul>
+ *   <li>public static TypeAdapter&lt;T&gt; typeAdapter() // No parameters</li>
+ *   <li>public static TypeAdapter&lt;T&gt; typeAdapter({@link Gson})</li>
+ *   <li>public static TypeAdapter&lt;T&gt; typeAdapter({@link Gson}, {@link Type}[])</li>
+ * </ul>
+ */
+@Retention(CLASS)
+@Target(TYPE)
+public @interface ExposeToGsonTypeAdapterFactory {
+}


### PR DESCRIPTION
This allows non-autovalue/non-extension-using classes to opt in to being picked up by the factory, which is a little more generalized from the extension now that it's public.

One open question - do we want to add a sibling mechanism here to suppress generation of the type adapter in autovalue classes if they expose a json adapter method that's just for the factory but returns a handwritten adapter?

Resolves #245 