### PR TITLE
Update an example in README with most recent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ public final class Foo_GsonTypeAdapter extends TypeAdapter<Foo> {
 
 // Using the runtime FACTORY
 new GsonBuilder()
-    .addTypeAdapterFactory(GenerateTypeAdapter.FACTORY)
-    .build()
+    .registerTypeAdapterFactory(GenerateTypeAdapter.FACTORY)
+    .create()
     .toJson(myFooInstance);
 ```
 


### PR DESCRIPTION
Hi,

I noticed the runtime FACTORY example was not using the latest GsonBuilder API.

Cheers