### PR TITLE
Recognize `@Nullable` as a `TYPE_USE` annotation.

### DIFF
--- a/auto-value-gson-extension/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
+++ b/auto-value-gson-extension/src/main/java/com/ryanharter/auto/value/gson/AutoValueGsonExtension.java
@@ -165,6 +165,9 @@ public class AutoValueGsonExtension extends AutoValueExtension {
       for (AnnotationMirror annotation : element.getAnnotationMirrors()) {
         builder.add(annotation.getAnnotationType().asElement().toString());
       }
+      for (AnnotationMirror annotation : element.getReturnType().getAnnotationMirrors()) {
+        builder.add(annotation.getAnnotationType().asElement().toString());
+      }
 
       return builder.build();
     }


### PR DESCRIPTION
Currently we only recognize it when it is applied to a getter method.
This change recognizes it when it is applied to the return type of a getter.
AutoValueExtension should probably include a helper method to do this.