### PR TITLE
Add support for omitting defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,35 @@ useful for setting default values.
 }
 ```
 
+### Omitting default values
+
+When using a builder, optional properties that are at their default values can optionally be emitted
+from the serialized JSON by annotating the class with `@OmitDefaults`.
+
+A property is considered optional if a value is set for it on the builder returned by the static
+builder method and the builder defines a getter method for it:
+
+```java
+@AutoValue public abstract class Foo {
+  abstract int bar();
+  abstract String quux();
+
+  public static Builder builderWithDefaults() {
+    return new AutoValue_Foo.Builder()
+        .quuz("QUUX");
+  }
+
+  @AutoValue.Builder
+  public static abstract class Builder {
+    public abstract Builder bar(int bar);
+    public abstract Builder quux(String quux);
+    // getter for quux
+    public abstract String quux();
+    public abstract Foo build();
+  }
+}
+```
+
 ## Field name policy
 
 If you want the generated adapter classes to use the input `Gson` instance's field name policy, you can 

--- a/auto-value-gson-runtime/src/main/java/com/ryanharter/auto/value/gson/OmitDefaults.java
+++ b/auto-value-gson-runtime/src/main/java/com/ryanharter/auto/value/gson/OmitDefaults.java
@@ -1,0 +1,28 @@
+package com.ryanharter.auto.value.gson;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+
+/**
+ * If present, optional properties at their default values will be omitted from the serialized JSON.
+ *
+ * <p>Requires the class to provide a static builder method returning an instance of the
+ * corresponding {@link com.google.auto.value.AutoValue.Builder} with the optional properties set
+ * to their default values.
+ *
+ * <p>A property is considered optional if
+ * <ul>
+ *   <li>a value is set for it on the builder returned by the static builder method and
+ *   <li>the builder defines a getter method for it ({@see
+ *   <a href="https://github.com/google/auto/blob/main/value/userguide/builders-howto.md#-normalize-modify-a-property-value-at-build-time">Auto Value documentation</a>}).
+ *   Builder getters returning {@link java.util.Optional} wrappers are not (yet) supported.
+ * </ul>
+ *
+ */
+@Retention(CLASS)
+@Target(TYPE)
+public @interface OmitDefaults {
+}

--- a/example/src/main/java/com/ryanharter/auto/value/gson/example/Person.java
+++ b/example/src/main/java/com/ryanharter/auto/value/gson/example/Person.java
@@ -3,9 +3,11 @@ package com.ryanharter.auto.value.gson.example;
 import com.google.auto.value.AutoValue;
 import com.google.gson.Gson;
 import com.google.gson.TypeAdapter;
+import com.ryanharter.auto.value.gson.OmitDefaults;
 import java.util.Date;
 
 @AutoValue
+@OmitDefaults
 public abstract class Person {
     public abstract String name();
 
@@ -32,9 +34,15 @@ public abstract class Person {
     public static abstract class Builder {
         public abstract Builder name(String name);
 
+        public abstract String name();
+
         public abstract Builder gender(int gender);
 
+        public abstract int gender();
+
         public abstract Builder age(int age);
+
+        public abstract int age();
 
         public abstract Builder birthdate(Date birthdate);
 

--- a/example/src/test/java/com/ryanharter/auto/value/gson/example/PersonTest.java
+++ b/example/src/test/java/com/ryanharter/auto/value/gson/example/PersonTest.java
@@ -6,6 +6,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
+import com.google.gson.JsonObject;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -75,5 +76,30 @@ public class PersonTest {
         Assert.assertEquals("Jane Doe", fromJson.name());
         Assert.assertEquals(23, fromJson.age());
         Assert.assertEquals(0, fromJson.gender());
+    }
+
+    @Test
+    public void testGsonWithDefaultsWrite() {
+        Gson gson = new GsonBuilder()
+            .registerTypeAdapterFactory(SampleAdapterFactory.create())
+            .create();
+
+        // gender has the default value and should be omitted from the output.
+        // name is also optional but not the default, it should be included.
+        // age has a builder getter defined, but isn't optional, it should be included.
+        Person toJson = Person.builder()
+            .name("Auto Value")
+            .gender(0)
+            .age(42)
+            .birthdate(new Date())
+            .address(Address.create("street", "city"))
+            .build();
+        String json = gson.toJson(toJson, Person.class);
+        JsonObject rawObject = gson.fromJson(json, JsonObject.class);
+        Assert.assertFalse(rawObject.has("gender"));
+        Assert.assertTrue(rawObject.has("name"));
+        Assert.assertEquals(rawObject.get("name").getAsString(), "Auto Value");
+        Assert.assertTrue(rawObject.has("age"));
+        Assert.assertEquals(rawObject.get("age").getAsInt(), 42);
     }
 }


### PR DESCRIPTION
If a class is annotated with the new `@OmitDefaults` annotation, which requires a builder, then all properties that have a value set by the default builder method and correspond to a getter function on the builder have their value omitted from the serialized JSON if it matches the default one.