### PR TITLE
Update another reference to javax.annotation.Generated

### DIFF
--- a/auto-value-gson-extension/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonExtensionTest.java
+++ b/auto-value-gson-extension/src/test/java/com/ryanharter/auto/value/gson/AutoValueGsonExtensionTest.java
@@ -841,7 +841,7 @@ public class AutoValueGsonExtensionTest {
         + "import java.util.List;\n"
         + "import java.util.Map;\n"
         + "import java.util.Set;\n"
-        + "import javax.annotation.Generated;\n"
+        + "import " + GENERATED + ";\n"
         + "\n"
         + "@Generated(\n"
         + "    value = \"com.ryanharter.auto.value.gson.AutoValueGsonExtension\",\n"


### PR DESCRIPTION
Use the `GENERATED` constant, which uses `javax.annotation.processing.Generated` instead on Java 9 and newer.